### PR TITLE
[feat] TopicCard 텍스트만 구현

### DIFF
--- a/src/components/TopicCard/SelectOption/SelectOption.stories.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+
+import TopicCard from '.';
+
+export default {
+  component: TopicCard,
+  title: 'Components/topic/SelectOption',
+};
+
+const Template: ComponentStory<typeof TopicCard> = (args) => <TopicCard {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  option: {
+    text: 'Text',
+  },
+};

--- a/src/components/TopicCard/SelectOption/SelectOption.stories.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.stories.tsx
@@ -12,26 +12,20 @@ const Template: ComponentStory<typeof TopicCard> = (args) => <TopicCard {...args
 
 export const Default = Template.bind({});
 Default.args = {
-  option: {
-    text: 'Text',
-  },
+  text: 'Text',
 };
 
 export const 선택한_결과 = Template.bind({});
 선택한_결과.args = {
-  option: {
-    text: 'Text',
-    rate: 0.86,
-  },
+  text: 'Text',
+  rate: 0.86,
   result: true,
   selected: true,
 };
 
 export const 선택안된_결과 = Template.bind({});
 선택안된_결과.args = {
-  option: {
-    text: 'Text',
-    rate: 0.24,
-  },
+  text: 'Text',
+  rate: 0.24,
   result: true,
 };

--- a/src/components/TopicCard/SelectOption/SelectOption.stories.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.stories.tsx
@@ -16,3 +16,22 @@ Default.args = {
     text: 'Text',
   },
 };
+
+export const 선택한_결과 = Template.bind({});
+선택한_결과.args = {
+  option: {
+    text: 'Text',
+    rate: 0.86,
+  },
+  result: true,
+  selected: true,
+};
+
+export const 선택안된_결과 = Template.bind({});
+선택안된_결과.args = {
+  option: {
+    text: 'Text',
+    rate: 0.24,
+  },
+  result: true,
+};

--- a/src/components/TopicCard/SelectOption/SelectOption.style.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.style.tsx
@@ -1,13 +1,14 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import theme from '@src/styles/theme';
 
-export const SelectOption = styled.div`
-  display: flex;
-  align-items: center;
-  padding: 20px 16px;
-  gap: 4px;
+interface ContainerProps {
+  $result: boolean;
+}
 
+export const Container = styled.div<ContainerProps>`
+  position: relative;
   width: 386px;
   height: 68px;
 
@@ -15,8 +16,46 @@ export const SelectOption = styled.div`
   border-radius: 4px;
 
   cursor: pointer;
+  ${({ $result }) =>
+    $result &&
+    css`
+      &:hover {
+        background-color: theme.color.G6;
+      }
+    `}
+`;
+
+export interface ProgressBarProps {
+  $rate: number;
+  $selected?: boolean;
+}
+
+export const ProgressBar = styled.div<ProgressBarProps>`
+  width: calc(${({ $rate }) => $rate} * 386px);
+  height: 100%;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  background-color: ${({ $selected }) => ($selected ? theme.color.Secondary1 : theme.color.G4)};
+  border-radius: 4px;
 
   &:hover {
-    background-color: ${theme.color.G6};
+    background-color: ${({ $selected }) => ($selected ? theme.color.Secondary2 : theme.color.G3)};
   }
+`;
+
+export const Info = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 20px 16px;
+  gap: 4px;
+
+  position: absolute;
+  width: 386px;
+`;
+
+export const Rate = styled.div`
+  margin-left: auto;
 `;

--- a/src/components/TopicCard/SelectOption/SelectOption.style.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.style.tsx
@@ -18,6 +18,7 @@ export const Container = styled.div<ContainerProps>`
   font-size: ${theme.textSize.T2};
 
   cursor: pointer;
+
   ${({ $result }) =>
     $result ||
     css`
@@ -56,6 +57,14 @@ export const Info = styled.div`
 
   position: absolute;
   width: 100%;
+`;
+
+export const Text = styled.div`
+  max-width: calc(100% - 75px);
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const Rate = styled.div`

--- a/src/components/TopicCard/SelectOption/SelectOption.style.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.style.tsx
@@ -13,4 +13,10 @@ export const SelectOption = styled.div`
 
   background-color: ${theme.color.G5};
   border-radius: 4px;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${theme.color.G6};
+  }
 `;

--- a/src/components/TopicCard/SelectOption/SelectOption.style.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.style.tsx
@@ -9,7 +9,6 @@ interface ContainerProps {
 
 export const Container = styled.div<ContainerProps>`
   position: relative;
-  width: 386px;
   height: 68px;
 
   background-color: ${theme.color.G5};
@@ -31,7 +30,7 @@ export interface ProgressBarProps {
 }
 
 export const ProgressBar = styled.div<ProgressBarProps>`
-  width: calc(${({ $rate }) => $rate} * 386px);
+  width: calc(${({ $rate }) => $rate} * 100%);
   height: 100%;
 
   position: absolute;
@@ -53,7 +52,7 @@ export const Info = styled.div`
   gap: 4px;
 
   position: absolute;
-  width: 386px;
+  width: 100%;
 `;
 
 export const Rate = styled.div`

--- a/src/components/TopicCard/SelectOption/SelectOption.style.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.style.tsx
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+import theme from '@src/styles/theme';
+
+export const SelectOption = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 20px 16px;
+  gap: 4px;
+
+  width: 386px;
+  height: 68px;
+
+  background-color: ${theme.color.G5};
+  border-radius: 4px;
+`;

--- a/src/components/TopicCard/SelectOption/SelectOption.style.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.style.tsx
@@ -14,6 +14,8 @@ export const Container = styled.div<ContainerProps>`
   background-color: ${theme.color.G5};
   border-radius: 4px;
 
+  font-size: ${theme.textSize.T2};
+
   cursor: pointer;
   ${({ $result }) =>
     $result &&

--- a/src/components/TopicCard/SelectOption/SelectOption.style.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.style.tsx
@@ -5,6 +5,7 @@ import theme from '@src/styles/theme';
 
 interface ContainerProps {
   $result: boolean;
+  $selected: boolean;
 }
 
 export const Container = styled.div<ContainerProps>`
@@ -18,12 +19,16 @@ export const Container = styled.div<ContainerProps>`
 
   cursor: pointer;
   ${({ $result }) =>
-    $result &&
+    $result ||
     css`
       &:hover {
-        background-color: theme.color.G6;
+        background-color: ${theme.color.G6};
       }
     `}
+
+  &:hover .progress {
+    background-color: ${({ $selected }) => ($selected ? theme.color.Secondary2 : theme.color.G3)};
+  }
 `;
 
 export interface ProgressBarProps {
@@ -41,10 +46,6 @@ export const ProgressBar = styled.div<ProgressBarProps>`
 
   background-color: ${({ $selected }) => ($selected ? theme.color.Secondary1 : theme.color.G4)};
   border-radius: 4px;
-
-  &:hover {
-    background-color: ${({ $selected }) => ($selected ? theme.color.Secondary2 : theme.color.G3)};
-  }
 `;
 
 export const Info = styled.div`

--- a/src/components/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import Icon from '@src/components/common/Icon';
+import { TopicOption } from '@src/types/Topic';
+
+import * as S from './SelectOption.style';
+
+interface SelectOption {
+  option: TopicOption;
+}
+
+const SelectOption = (props: SelectOption) => {
+  const { option } = props;
+
+  return (
+    <S.SelectOption>
+      <Icon name="Vote" />
+      {option.text}
+    </S.SelectOption>
+  );
+};
+
+export default SelectOption;

--- a/src/components/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.tsx
@@ -20,8 +20,8 @@ const SelectOption = (props: SelectOptionProps) => {
   };
 
   return (
-    <S.Container $result={result} onClick={handleClick}>
-      {result && <S.ProgressBar $rate={rate} $selected={selected} />}
+    <S.Container $result={result} $selected={selected} onClick={handleClick}>
+      {result && <S.ProgressBar className="progress" $rate={rate} $selected={selected} />}
       <S.Info>
         <Icon name="Vote" />
         {text}

--- a/src/components/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.tsx
@@ -5,18 +5,25 @@ import { TopicOption } from '@src/types/Topic';
 
 import * as S from './SelectOption.style';
 
-interface SelectOption {
+interface SelectOptionProps {
   option: TopicOption;
+  result?: boolean;
+  selected?: boolean;
 }
 
-const SelectOption = (props: SelectOption) => {
-  const { option } = props;
+const SelectOption = (props: SelectOptionProps) => {
+  const { option, result = false, selected = false } = props;
+  const { text, rate = 0 } = option;
 
   return (
-    <S.SelectOption>
-      <Icon name="Vote" />
-      {option.text}
-    </S.SelectOption>
+    <S.Container $result={result}>
+      {result && <S.ProgressBar $rate={rate} $selected={selected} />}
+      <S.Info>
+        <Icon name="Vote" />
+        {text}
+        {result && <S.Rate>{Math.round(rate * 100)}%</S.Rate>}
+      </S.Info>
+    </S.Container>
   );
 };
 

--- a/src/components/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.tsx
@@ -6,15 +6,21 @@ import { TopicOption } from '@src/types/Topic';
 import * as S from './SelectOption.style';
 
 interface SelectOptionProps extends TopicOption {
+  rate?: number;
   result?: boolean;
   selected?: boolean;
+  onClick: (id: number, selected: boolean) => void;
 }
 
 const SelectOption = (props: SelectOptionProps) => {
-  const { text, rate = 0, result = false, selected = false } = props;
+  const { id, text, rate = 0, result = false, selected = false, onClick } = props;
+
+  const handleClick = () => {
+    onClick(id, selected);
+  };
 
   return (
-    <S.Container $result={result}>
+    <S.Container $result={result} onClick={handleClick}>
       {result && <S.ProgressBar $rate={rate} $selected={selected} />}
       <S.Info>
         <Icon name="Vote" />

--- a/src/components/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.tsx
@@ -24,7 +24,7 @@ const SelectOption = (props: SelectOptionProps) => {
       {result && <S.ProgressBar className="progress" $rate={rate} $selected={selected} />}
       <S.Info>
         <Icon name="Vote" />
-        {text}
+        <S.Text>{text}</S.Text>
         {result && <S.Rate>{Math.round(rate * 100)}%</S.Rate>}
       </S.Info>
     </S.Container>

--- a/src/components/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/TopicCard/SelectOption/SelectOption.tsx
@@ -5,15 +5,13 @@ import { TopicOption } from '@src/types/Topic';
 
 import * as S from './SelectOption.style';
 
-interface SelectOptionProps {
-  option: TopicOption;
+interface SelectOptionProps extends TopicOption {
   result?: boolean;
   selected?: boolean;
 }
 
 const SelectOption = (props: SelectOptionProps) => {
-  const { option, result = false, selected = false } = props;
-  const { text, rate = 0 } = option;
+  const { text, rate = 0, result = false, selected = false } = props;
 
   return (
     <S.Container $result={result}>

--- a/src/components/TopicCard/SelectOption/index.tsx
+++ b/src/components/TopicCard/SelectOption/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './SelectOption';
+export * from './SelectOption';

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -5,7 +5,7 @@ import TopicCard from '.';
 
 export default {
   component: TopicCard,
-  title: 'Components/TopicCard',
+  title: 'Components/topic/TopicCard',
 };
 
 const Template: ComponentStory<typeof TopicCard> = (args) => <TopicCard {...args} />;
@@ -24,7 +24,7 @@ Default.args = {
       nickname: '닉네임',
       profileImage: '',
     },
-    participations: 0,
+    participation: 0,
     comments: 0,
   },
 };

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -21,7 +21,7 @@ Default.args = {
   member: {
     jobCategory: '개발자',
     nickname: '닉네임',
-    profileImage: '',
+    profileImage: 'https://avatars.githubusercontent.com/u/45786387?v=4',
   },
   comments: 0,
   type: 'feed',

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+
+import TopicCard from '.';
+
+export default {
+  component: TopicCard,
+  title: 'Components/TopicCard',
+};
+
+const Template: ComponentStory<typeof TopicCard> = (args) => <TopicCard {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  topic: {
+    title: 'Title',
+    contents: 'contents',
+    options: [
+      { id: 0, text: 'text' },
+      { id: 1, text: 'text' },
+    ],
+    member: {
+      jobCategory: '개발자',
+      nickname: '닉네임',
+      profileImage: '',
+    },
+    participations: 0,
+    comments: 0,
+  },
+};

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -27,6 +27,25 @@ Default.args = {
   type: 'feed',
 };
 
+export const 글자수_많음_2개 = Template.bind({});
+글자수_많음_2개.args = {
+  ...Default.args,
+  options: [
+    { id: 0, text: '일이삼사오육칠팔구십일이삼사오육칠팔구십', voters: 10 },
+    { id: 1, text: '일이삼사오육칠팔구십일이삼사오육칠팔구십', voters: 20 },
+  ],
+};
+
+export const 글자수_많음_3개 = Template.bind({});
+글자수_많음_3개.args = {
+  ...Default.args,
+  options: [
+    { id: 0, text: '일이삼사오육칠팔구십일이삼사오육칠팔구십', voters: 10 },
+    { id: 1, text: '일이삼사오육칠팔구십일이삼사오육칠팔구십', voters: 10 },
+    { id: 2, text: '일이삼사오육칠팔구십일이삼사오육칠팔구십', voters: 30 },
+  ],
+};
+
 export const Badge = Template.bind({});
 Badge.args = {
   ...Default.args,

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -27,6 +27,12 @@ Default.args = {
   type: 'feed',
 };
 
+export const Badge = Template.bind({});
+Badge.args = {
+  ...Default.args,
+  badge: 'badge',
+};
+
 export const Detail = Template.bind({});
 Detail.args = {
   ...Default.args,

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -24,6 +24,13 @@ Default.args = {
     profileImage: '',
   },
   comments: 0,
+  type: 'feed',
+};
+
+export const Detail = Template.bind({});
+Detail.args = {
+  ...Default.args,
+  type: 'detail',
 };
 
 export const ThreeOptions = Template.bind({});

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -12,19 +12,17 @@ const Template: ComponentStory<typeof TopicCard> = (args) => <TopicCard {...args
 
 export const Default = Template.bind({});
 Default.args = {
-  topic: {
-    title: 'Title',
-    contents: 'contents',
-    options: [
-      { id: 0, text: 'text' },
-      { id: 1, text: 'text' },
-    ],
-    member: {
-      jobCategory: '개발자',
-      nickname: '닉네임',
-      profileImage: '',
-    },
-    participation: 0,
-    comments: 0,
+  title: 'Title',
+  contents: 'contents',
+  options: [
+    { id: 0, text: 'text' },
+    { id: 1, text: 'text' },
+  ],
+  member: {
+    jobCategory: '개발자',
+    nickname: '닉네임',
+    profileImage: '',
   },
+  participation: 0,
+  comments: 0,
 };

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -26,3 +26,24 @@ Default.args = {
   participation: 0,
   comments: 0,
 };
+
+export const ThreeOptions = Template.bind({});
+ThreeOptions.args = {
+  ...Default.args,
+  options: [
+    { id: 0, text: 'text' },
+    { id: 1, text: 'text' },
+    { id: 2, text: 'text' },
+  ],
+};
+
+export const FourOptions = Template.bind({});
+FourOptions.args = {
+  ...Default.args,
+  options: [
+    { id: 0, text: 'text' },
+    { id: 1, text: 'text' },
+    { id: 2, text: 'text' },
+    { id: 3, text: 'text' },
+  ],
+};

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -23,7 +23,6 @@ Default.args = {
     nickname: '닉네임',
     profileImage: '',
   },
-  participant: 0,
   comments: 0,
 };
 

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -15,15 +15,15 @@ Default.args = {
   title: 'Title',
   contents: 'contents',
   options: [
-    { id: 0, text: 'text' },
-    { id: 1, text: 'text' },
+    { id: 0, text: 'text', voters: 0 },
+    { id: 1, text: 'text', voters: 0 },
   ],
   member: {
     jobCategory: '개발자',
     nickname: '닉네임',
     profileImage: '',
   },
-  participation: 0,
+  participant: 0,
   comments: 0,
 };
 
@@ -31,9 +31,9 @@ export const ThreeOptions = Template.bind({});
 ThreeOptions.args = {
   ...Default.args,
   options: [
-    { id: 0, text: 'text' },
-    { id: 1, text: 'text' },
-    { id: 2, text: 'text' },
+    { id: 0, text: 'text', voters: 0 },
+    { id: 1, text: 'text', voters: 0 },
+    { id: 2, text: 'text', voters: 0 },
   ],
 };
 
@@ -41,9 +41,9 @@ export const FourOptions = Template.bind({});
 FourOptions.args = {
   ...Default.args,
   options: [
-    { id: 0, text: 'text' },
-    { id: 1, text: 'text' },
-    { id: 2, text: 'text' },
-    { id: 3, text: 'text' },
+    { id: 0, text: 'text', voters: 0 },
+    { id: 1, text: 'text', voters: 0 },
+    { id: 2, text: 'text', voters: 0 },
+    { id: 3, text: 'text', voters: 0 },
   ],
 };

--- a/src/components/TopicCard/TopicCard.stories.tsx
+++ b/src/components/TopicCard/TopicCard.stories.tsx
@@ -30,9 +30,9 @@ export const ThreeOptions = Template.bind({});
 ThreeOptions.args = {
   ...Default.args,
   options: [
-    { id: 0, text: 'text', voters: 0 },
-    { id: 1, text: 'text', voters: 0 },
-    { id: 2, text: 'text', voters: 0 },
+    { id: 0, text: 'text', voters: 10 },
+    { id: 1, text: 'text', voters: 20 },
+    { id: 2, text: 'text', voters: 4 },
   ],
 };
 
@@ -40,9 +40,9 @@ export const FourOptions = Template.bind({});
 FourOptions.args = {
   ...Default.args,
   options: [
-    { id: 0, text: 'text', voters: 0 },
-    { id: 1, text: 'text', voters: 0 },
-    { id: 2, text: 'text', voters: 0 },
-    { id: 3, text: 'text', voters: 0 },
+    { id: 0, text: 'text', voters: 10 },
+    { id: 1, text: 'text', voters: 2 },
+    { id: 2, text: 'text', voters: 34 },
+    { id: 3, text: 'text', voters: 3 },
   ],
 };

--- a/src/components/TopicCard/TopicCard.style.tsx
+++ b/src/components/TopicCard/TopicCard.style.tsx
@@ -1,0 +1,103 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+
+import theme from '@src/styles/theme';
+
+export const Container = styled.div`
+  width: 857px;
+
+  background-color: ${theme.color.G3};
+
+  border-radius: 8px;
+`;
+
+export const TopicTop = styled.div`
+  padding: 28px 32px 20px;
+
+  border-bottom: 1px solid ${theme.color.G4};
+`;
+
+export const Title = styled.h3`
+  margin-bottom: 8px;
+
+  font-size: ${theme.textSize.H3};
+  font-weight: ${theme.fontWeight.bold};
+  color: ${theme.color.G8};
+`;
+
+export const Contents = styled.div`
+  margin-bottom: 24px;
+
+  font-size: ${theme.textSize.B2};
+  font-weight: ${theme.fontWeight.regular};
+  color: ${theme.color.G8};
+`;
+
+export const SelectOptionContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+  padding: 0;
+  gap: 20px;
+`;
+
+export const SelectOption = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 20px 16px;
+  gap: 4px;
+
+  width: 386px;
+  height: 68px;
+
+  background-color: ${theme.color.G5};
+  border-radius: 4px;
+`;
+
+export const TopicBottom = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 32px;
+
+  height: 60px;
+
+  font-size: ${theme.textSize.B3};
+  color: ${theme.color.G7};
+  white-space: nowrap;
+`;
+
+export const AuthorInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const Profile = styled(Image)`
+  min-width: 28px;
+  min-height: 28px;
+  width: 28px;
+  height: 28px;
+
+  font-size: 0;
+  background-color: ${theme.color.G7};
+
+  border-radius: 50%;
+`;
+
+export const TopicInfoContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: end;
+  gap: 8px;
+`;
+
+export const TopicInfo = styled.span`
+  display: flex;
+  flex-direction: row;
+  padding: 0;
+  gap: 2px;
+
+  svg {
+    margin-top: -2px;
+  }
+`;

--- a/src/components/TopicCard/TopicCard.style.tsx
+++ b/src/components/TopicCard/TopicCard.style.tsx
@@ -17,6 +17,11 @@ export const TopicTop = styled.div`
   border-bottom: 1px solid ${theme.color.G4};
 `;
 
+export const TopicHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
 export const Title = styled.h3`
   margin-bottom: 8px;
 

--- a/src/components/TopicCard/TopicCard.style.tsx
+++ b/src/components/TopicCard/TopicCard.style.tsx
@@ -34,6 +34,8 @@ export const Badge = styled.div`
   font-size: ${theme.textSize.B3};
   line-height: ${theme.lineHeight.B};
   color: ${theme.color.Primary1};
+
+  cursor: pointer;
 `;
 
 export const TopicHeader = styled.div`

--- a/src/components/TopicCard/TopicCard.style.tsx
+++ b/src/components/TopicCard/TopicCard.style.tsx
@@ -40,19 +40,6 @@ export const SelectOptionContainer = styled.div`
   gap: 20px;
 `;
 
-export const SelectOption = styled.div`
-  display: flex;
-  align-items: center;
-  padding: 20px 16px;
-  gap: 4px;
-
-  width: 386px;
-  height: 68px;
-
-  background-color: ${theme.color.G5};
-  border-radius: 4px;
-`;
-
 export const TopicBottom = styled.div`
   display: flex;
   justify-content: space-between;

--- a/src/components/TopicCard/TopicCard.style.tsx
+++ b/src/components/TopicCard/TopicCard.style.tsx
@@ -17,6 +17,25 @@ export const TopicTop = styled.div`
   border-bottom: 1px solid ${theme.color.G4};
 `;
 
+export const Badge = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  gap: 2px;
+
+  width: fit-content;
+  height: 34px;
+
+  background: ${theme.color.G4};
+  border-radius: 4px;
+
+  font-weight: ${theme.fontWeight.bold};
+  font-size: ${theme.textSize.B3};
+  line-height: ${theme.lineHeight.B};
+  color: ${theme.color.Primary1};
+`;
+
 export const TopicHeader = styled.div`
   display: flex;
   justify-content: space-between;

--- a/src/components/TopicCard/TopicCard.style.tsx
+++ b/src/components/TopicCard/TopicCard.style.tsx
@@ -33,9 +33,13 @@ export const Contents = styled.div`
   color: ${theme.color.G8};
 `;
 
-export const SelectOptionContainer = styled.div`
-  display: flex;
-  align-items: flex-start;
+interface SelectOptionContainerProps {
+  $odd?: boolean;
+}
+
+export const SelectOptionContainer = styled.div<SelectOptionContainerProps>`
+  display: grid;
+  grid-template-columns: 1fr 1fr ${({ $odd }) => $odd && '1fr'};
   padding: 0;
   gap: 20px;
 `;

--- a/src/components/TopicCard/TopicCard.style.tsx
+++ b/src/components/TopicCard/TopicCard.style.tsx
@@ -80,6 +80,22 @@ export const Profile = styled(Image)`
   border-radius: 50%;
 `;
 
+export const LikeBtn = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0px 12px;
+  gap: 2px;
+
+  height: 36px;
+
+  background-color: transparent;
+  color: ${theme.color.G7};
+
+  border: 1px solid ${theme.color.G5};
+  border-radius: 100px;
+`;
+
 export const TopicInfoContainer = styled.div`
   display: flex;
   align-items: center;

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -16,7 +16,10 @@ const TopicCard = (props: TopicCardProps) => {
   return (
     <S.Container>
       <S.TopicTop>
-        <S.Title>{title}</S.Title>
+        <S.TopicHeader>
+          <S.Title>{title}</S.Title>
+          <Icon name="Share" />
+        </S.TopicHeader>
         <S.Contents>{contents}</S.Contents>
         <S.SelectOptionContainer $odd={options.length % 2 === 1}>
           {options.map((option) => (

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -6,16 +6,20 @@ import Icon from '../common/Icon';
 import SelectOption from './SelectOption';
 import * as S from './TopicCard.style';
 
+export type TopicCardType = 'feed' | 'detail';
+
 interface TopicCardProps extends Topic {
   badge?: string;
+  type: TopicCardType;
 }
 
 const TopicCard = (props: TopicCardProps) => {
-  const { title, contents, options: defaultOptions, member, comments } = props;
+  const { title, contents, options: defaultOptions, member, comments, type } = props;
   const [options, setOptions] = useState<TopicOption[]>(defaultOptions);
   const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null); // TODO: 초기 선택 여부 확인해야함
 
   const participant = options.reduce((prev, option) => prev + option.voters, 0);
+  const isFeed = type === 'feed';
 
   const handleClickOption = (id: number) => {
     const changed = options.map((option) => {
@@ -41,7 +45,7 @@ const TopicCard = (props: TopicCardProps) => {
       <S.TopicTop>
         <S.TopicHeader>
           <S.Title>{title}</S.Title>
-          <Icon name="Share" />
+          {isFeed && <Icon name="Share" />}
         </S.TopicHeader>
         <S.Contents>{contents}</S.Contents>
         <S.SelectOptionContainer $odd={options.length % 2 === 1}>
@@ -58,10 +62,17 @@ const TopicCard = (props: TopicCardProps) => {
         </S.SelectOptionContainer>
       </S.TopicTop>
       <S.TopicBottom>
-        <S.AuthorInfo>
-          <S.Profile src={member.profileImage} alt={member.nickname} />
-          <span>{member.nickname}</span>
-        </S.AuthorInfo>
+        {isFeed ? (
+          <S.AuthorInfo>
+            <S.Profile src={member.profileImage} alt={member.nickname} />
+            <span>{member.nickname}</span>
+          </S.AuthorInfo>
+        ) : (
+          <S.LikeBtn>
+            <Icon name="Clap" color="G7" size={24} />
+            <span>좋아요</span>
+          </S.LikeBtn>
+        )}
         <S.TopicInfoContainer>
           <S.TopicInfo>
             <Icon name="HandsUp" size={16} />

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -74,7 +74,7 @@ const TopicCard = (props: TopicCardProps) => {
       <S.TopicBottom>
         {isFeed ? (
           <S.AuthorInfo>
-            <S.Profile src={member.profileImage} alt={member.nickname} />
+            <S.Profile src={member.profileImage} alt={member.nickname} width="28" height="28" />
             <span>{member.nickname}</span>
           </S.AuthorInfo>
         ) : (

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import Topic from '@src/types/Topic';
+import Topic, { TopicOption } from '@src/types/Topic';
 
 import Icon from '../common/Icon';
 import SelectOption from './SelectOption';
@@ -11,7 +11,33 @@ interface TopicCardProps extends Topic {
 }
 
 const TopicCard = (props: TopicCardProps) => {
-  const { title, contents, options, member, participation, comments } = props;
+  const { title, contents, options: defaultOptions, member, participant: defaultParticipant, comments } = props;
+  const [options, setOptions] = useState<TopicOption[]>(defaultOptions);
+  const [participant, setParticipant] = useState<number>(defaultParticipant);
+  const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null); // TODO: 초기 선택 여부 확인해야함
+
+  const handleClickOption = (id: number) => {
+    const changed = options.map((option) => {
+      if (option.id === selectedOptionId) {
+        option.voters -= 1;
+        return option;
+      }
+      if (option.id === id) {
+        option.voters += 1;
+      }
+      return option;
+    });
+    setOptions(changed);
+    setSelectedOptionId(id);
+
+    if (selectedOptionId === id) {
+      setParticipant((prev) => prev - 1);
+      setSelectedOptionId(null);
+    }
+    if (selectedOptionId === null) {
+      setParticipant((prev) => prev + 1);
+    }
+  };
 
   return (
     <S.Container>
@@ -23,7 +49,14 @@ const TopicCard = (props: TopicCardProps) => {
         <S.Contents>{contents}</S.Contents>
         <S.SelectOptionContainer $odd={options.length % 2 === 1}>
           {options.map((option) => (
-            <SelectOption key={option.id} {...option} />
+            <SelectOption
+              key={option.id}
+              {...option}
+              rate={option.voters / participant}
+              result={selectedOptionId !== null}
+              selected={selectedOptionId === option.id}
+              onClick={handleClickOption}
+            />
           ))}
         </S.SelectOptionContainer>
       </S.TopicTop>
@@ -35,7 +68,7 @@ const TopicCard = (props: TopicCardProps) => {
         <S.TopicInfoContainer>
           <S.TopicInfo>
             <Icon name="HandsUp" size={16} />
-            {('00' + participation).slice(-3)}명 참여
+            {('00' + participant).slice(-3)}명 참여
           </S.TopicInfo>
           ·
           <S.TopicInfo>

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -6,14 +6,12 @@ import Icon from '../common/Icon';
 import SelectOption from './SelectOption';
 import * as S from './TopicCard.style';
 
-interface TopicCardProps {
-  topic: Topic;
+interface TopicCardProps extends Topic {
   badge?: string;
 }
 
 const TopicCard = (props: TopicCardProps) => {
-  const { topic } = props;
-  const { title, contents, options, member, participation, comments } = topic;
+  const { title, contents, options, member, participation, comments } = props;
 
   return (
     <S.Container>

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -11,10 +11,11 @@ interface TopicCardProps extends Topic {
 }
 
 const TopicCard = (props: TopicCardProps) => {
-  const { title, contents, options: defaultOptions, member, participant: defaultParticipant, comments } = props;
+  const { title, contents, options: defaultOptions, member, comments } = props;
   const [options, setOptions] = useState<TopicOption[]>(defaultOptions);
-  const [participant, setParticipant] = useState<number>(defaultParticipant);
   const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null); // TODO: 초기 선택 여부 확인해야함
+
+  const participant = options.reduce((prev, option) => prev + option.voters, 0);
 
   const handleClickOption = (id: number) => {
     const changed = options.map((option) => {
@@ -31,11 +32,7 @@ const TopicCard = (props: TopicCardProps) => {
     setSelectedOptionId(id);
 
     if (selectedOptionId === id) {
-      setParticipant((prev) => prev - 1);
       setSelectedOptionId(null);
-    }
-    if (selectedOptionId === null) {
-      setParticipant((prev) => prev + 1);
     }
   };
 

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -73,7 +73,7 @@ const TopicCard = (props: TopicCardProps) => {
           ·
           <S.TopicInfo>
             <Icon name="Bubble" size={16} />
-            {('00' + comments).slice(-3)}명 참여
+            {('00' + comments).slice(-3)}개 댓글
           </S.TopicInfo>
         </S.TopicInfoContainer>
       </S.TopicBottom>

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import Topic from '@src/types/Topic';
+
+import Icon from '../common/Icon';
+import * as S from './TopicCard.style';
+
+interface TopicCardProps {
+  topic: Topic;
+  badge?: string;
+}
+
+const TopicCard = (props: TopicCardProps) => {
+  const { topic } = props;
+  const { title, contents, options, member, participations, comments } = topic;
+
+  return (
+    <S.Container>
+      <S.TopicTop>
+        <S.Title>{title}</S.Title>
+        <S.Contents>{contents}</S.Contents>
+        <S.SelectOptionContainer>
+          {options.map((option) => (
+            <S.SelectOption key={option.id}>
+              <Icon name="Vote" />
+              {option.text}
+            </S.SelectOption>
+          ))}
+        </S.SelectOptionContainer>
+      </S.TopicTop>
+      <S.TopicBottom>
+        <S.AuthorInfo>
+          <S.Profile src={member.profileImage} alt={member.nickname} />
+          <span>{member.nickname}</span>
+        </S.AuthorInfo>
+        <S.TopicInfoContainer>
+          <S.TopicInfo>
+            <Icon name="HandsUp" size={16} />
+            {('00' + participations).slice(-3)}명 참여
+          </S.TopicInfo>
+          ·
+          <S.TopicInfo>
+            <Icon name="Bubble" size={16} />
+            {('00' + comments).slice(-3)}명 참여
+          </S.TopicInfo>
+        </S.TopicInfoContainer>
+      </S.TopicBottom>
+    </S.Container>
+  );
+};
+
+export default TopicCard;

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Topic from '@src/types/Topic';
 
 import Icon from '../common/Icon';
+import SelectOption from './SelectOption';
 import * as S from './TopicCard.style';
 
 interface TopicCardProps {
@@ -12,7 +13,7 @@ interface TopicCardProps {
 
 const TopicCard = (props: TopicCardProps) => {
   const { topic } = props;
-  const { title, contents, options, member, participations, comments } = topic;
+  const { title, contents, options, member, participation, comments } = topic;
 
   return (
     <S.Container>
@@ -21,10 +22,7 @@ const TopicCard = (props: TopicCardProps) => {
         <S.Contents>{contents}</S.Contents>
         <S.SelectOptionContainer>
           {options.map((option) => (
-            <S.SelectOption key={option.id}>
-              <Icon name="Vote" />
-              {option.text}
-            </S.SelectOption>
+            <SelectOption key={option.id} option={option} />
           ))}
         </S.SelectOptionContainer>
       </S.TopicTop>
@@ -36,7 +34,7 @@ const TopicCard = (props: TopicCardProps) => {
         <S.TopicInfoContainer>
           <S.TopicInfo>
             <Icon name="HandsUp" size={16} />
-            {('00' + participations).slice(-3)}명 참여
+            {('00' + participation).slice(-3)}명 참여
           </S.TopicInfo>
           ·
           <S.TopicInfo>

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -18,7 +18,7 @@ const TopicCard = (props: TopicCardProps) => {
       <S.TopicTop>
         <S.Title>{title}</S.Title>
         <S.Contents>{contents}</S.Contents>
-        <S.SelectOptionContainer>
+        <S.SelectOptionContainer $odd={options.length % 2 === 1}>
           {options.map((option) => (
             <SelectOption key={option.id} {...option} />
           ))}

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -9,12 +9,12 @@ import * as S from './TopicCard.style';
 export type TopicCardType = 'feed' | 'detail';
 
 interface TopicCardProps extends Topic {
-  badge?: string;
+  badge?: string; // TODO: Icon등의 형태 논의 필요
   type: TopicCardType;
 }
 
 const TopicCard = (props: TopicCardProps) => {
-  const { title, contents, options: defaultOptions, member, comments, type } = props;
+  const { title, contents, options: defaultOptions, member, comments, badge, type } = props;
   const [options, setOptions] = useState<TopicOption[]>(defaultOptions);
   const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null); // TODO: 초기 선택 여부 확인해야함
 
@@ -38,13 +38,23 @@ const TopicCard = (props: TopicCardProps) => {
     if (selectedOptionId === id) {
       setSelectedOptionId(null);
     }
+
+    // TODO: api
   };
 
   return (
     <S.Container>
       <S.TopicTop>
         <S.TopicHeader>
-          <S.Title>{title}</S.Title>
+          <div>
+            {badge && (
+              <S.Badge>
+                <Icon name="ThumbsUp" size={18} />
+                {badge}
+              </S.Badge>
+            )}
+            <S.Title>{title}</S.Title>
+          </div>
           {isFeed && <Icon name="Share" />}
         </S.TopicHeader>
         <S.Contents>{contents}</S.Contents>

--- a/src/components/TopicCard/TopicCard.tsx
+++ b/src/components/TopicCard/TopicCard.tsx
@@ -22,7 +22,7 @@ const TopicCard = (props: TopicCardProps) => {
         <S.Contents>{contents}</S.Contents>
         <S.SelectOptionContainer>
           {options.map((option) => (
-            <SelectOption key={option.id} option={option} />
+            <SelectOption key={option.id} {...option} />
           ))}
         </S.SelectOptionContainer>
       </S.TopicTop>

--- a/src/components/TopicCard/index.tsx
+++ b/src/components/TopicCard/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './TopicCard';
+export * from './TopicCard';

--- a/src/types/Member.ts
+++ b/src/types/Member.ts
@@ -1,0 +1,6 @@
+export default interface Member {
+  id?: number;
+  jobCategory: string;
+  nickname: string;
+  profileImage: string;
+}

--- a/src/types/Topic.ts
+++ b/src/types/Topic.ts
@@ -6,7 +6,7 @@ export default interface Topic {
   contents: string;
   options: TopicOption[];
   member: Member;
-  participations: number;
+  participation: number;
   comments: number;
 }
 

--- a/src/types/Topic.ts
+++ b/src/types/Topic.ts
@@ -1,0 +1,16 @@
+import Member from './Member';
+
+export default interface Topic {
+  id?: number;
+  title: string;
+  contents: string;
+  options: TopicOption[];
+  member: Member;
+  participations: number;
+  comments: number;
+}
+
+export interface TopicOption {
+  id?: number;
+  text: string;
+}

--- a/src/types/Topic.ts
+++ b/src/types/Topic.ts
@@ -13,4 +13,5 @@ export default interface Topic {
 export interface TopicOption {
   id?: number;
   text: string;
+  rate?: number;
 }

--- a/src/types/Topic.ts
+++ b/src/types/Topic.ts
@@ -6,12 +6,12 @@ export default interface Topic {
   contents: string;
   options: TopicOption[];
   member: Member;
-  participation: number;
+  participant: number;
   comments: number;
 }
 
 export interface TopicOption {
-  id?: number;
+  id: number;
   text: string;
-  rate?: number;
+  voters: number;
 }

--- a/src/types/Topic.ts
+++ b/src/types/Topic.ts
@@ -6,7 +6,6 @@ export default interface Topic {
   contents: string;
   options: TopicOption[];
   member: Member;
-  participant: number;
   comments: number;
 }
 


### PR DESCRIPTION
close #29 

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

![image](https://user-images.githubusercontent.com/45786387/211047371-8c943816-41ec-4bdc-a065-60409db38ae9.png)
![image](https://user-images.githubusercontent.com/45786387/211047411-b365ed70-df68-4024-a132-21665321c362.png)
![image](https://user-images.githubusercontent.com/45786387/211047441-de92b1ac-2555-4560-a6a0-9e32ca612b96.png)


## 📝 작업 내용
<!-- 작업 내용 -->

 - 토픽 카드를 구현했습니다.

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

 - 나중에 api 붙이면서 논의하거나 추가구현할 게 몇 가지 있습니다. TODO로 작성해둠!
   - badge 넣을 때 어캐 받을건지
   - 내가 투표한 거 초기 값 받기
   - api 확인하고 붙이기
 - next/image가 허용하는 domain을 따로 설정해줘야할 것 같습니다. [참고](https://nextjs.org/docs/basic-features/image-optimization)
 - styled-components props사용 시 `$`를 써봤는데 괜찮은건지 모르겠네요... 🤔
 의견을 구합니닷!
 써본 이유는 [이런 오류](https://mygumi.tistory.com/382)가 발생했어서 찾아보다 적용하게 되었습니다.
 [$ 사용 시 styled-componts에서만 가져가도록 한다고](https://styled-components.com/docs/api#transient-props) 하네요.

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->
- 주의사항 한 번 확인 부탁드립니다!
