### PR TITLE
[feat] grid system 및 기본 레이아웃 구현

### DIFF
--- a/src/components/DefaultLayout/DefaultLayout.stories.tsx
+++ b/src/components/DefaultLayout/DefaultLayout.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+
+import DefaultLayout from '.';
+
+export default {
+  component: DefaultLayout,
+  title: 'Components/DefaultLayout',
+};
+
+const Template: ComponentStory<typeof DefaultLayout> = (args) => <DefaultLayout {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  left: '왼쪽입니다.',
+  main: '메인입니다.',
+};

--- a/src/components/DefaultLayout/DefaultLayout.stories.tsx
+++ b/src/components/DefaultLayout/DefaultLayout.stories.tsx
@@ -12,6 +12,6 @@ const Template: ComponentStory<typeof DefaultLayout> = (args) => <DefaultLayout 
 
 export const Default = Template.bind({});
 Default.args = {
-  left: '왼쪽입니다.',
+  side: '왼쪽입니다.',
   main: '메인입니다.',
 };

--- a/src/components/DefaultLayout/DefaultLayout.style.tsx
+++ b/src/components/DefaultLayout/DefaultLayout.style.tsx
@@ -1,0 +1,3 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div``;

--- a/src/components/DefaultLayout/DefaultLayout.style.tsx
+++ b/src/components/DefaultLayout/DefaultLayout.style.tsx
@@ -1,3 +1,0 @@
-import styled from '@emotion/styled';
-
-export const Container = styled.div``;

--- a/src/components/DefaultLayout/DefaultLayout.tsx
+++ b/src/components/DefaultLayout/DefaultLayout.tsx
@@ -3,23 +3,21 @@ import React, { ReactNode } from 'react';
 import Header from '@src/components/Header';
 import Grid from '@src/components/common/Grid';
 
-import * as S from './DefaultLayout.style';
-
 interface DefaultLayoutProps {
-  left: ReactNode;
+  side: ReactNode;
   main: ReactNode;
 }
 
 const DefaultLayout = (props: DefaultLayoutProps) => {
-  const { left, main } = props;
+  const { side, main } = props;
   return (
-    <S.Container>
+    <>
       <Header />
       <Grid container>
-        <Grid column={3}>{left}</Grid>
+        <Grid column={3}>{side}</Grid>
         <Grid>{main}</Grid>
       </Grid>
-    </S.Container>
+    </>
   );
 };
 

--- a/src/components/DefaultLayout/DefaultLayout.tsx
+++ b/src/components/DefaultLayout/DefaultLayout.tsx
@@ -10,7 +10,7 @@ interface DefaultLayoutProps {
   main: ReactNode;
 }
 
-const MyButton = (props: DefaultLayoutProps) => {
+const DefaultLayout = (props: DefaultLayoutProps) => {
   const { left, main } = props;
   return (
     <S.Container>
@@ -23,4 +23,4 @@ const MyButton = (props: DefaultLayoutProps) => {
   );
 };
 
-export default MyButton;
+export default DefaultLayout;

--- a/src/components/DefaultLayout/DefaultLayout.tsx
+++ b/src/components/DefaultLayout/DefaultLayout.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode } from 'react';
+
+import Header from '@src/components/Header';
+import Grid from '@src/components/common/Grid';
+
+import * as S from './DefaultLayout.style';
+
+interface DefaultLayoutProps {
+  left: ReactNode;
+  main: ReactNode;
+}
+
+const MyButton = (props: DefaultLayoutProps) => {
+  const { left, main } = props;
+  return (
+    <S.Container>
+      <Header />
+      <Grid container>
+        <Grid column={3}>{left}</Grid>
+        <Grid>{main}</Grid>
+      </Grid>
+    </S.Container>
+  );
+};
+
+export default MyButton;

--- a/src/components/DefaultLayout/index.tsx
+++ b/src/components/DefaultLayout/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './DefaultLayout';

--- a/src/components/common/Grid/Grid.stories.tsx
+++ b/src/components/common/Grid/Grid.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Grid from '.';
+
+export default {
+  title: 'Commons/Grid',
+  component: Grid,
+  argTypes: {
+    container: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as ComponentMeta<typeof Grid>;
+
+const Template: ComponentStory<typeof Grid> = ({ ...args }) => (
+  <Grid container>
+    <Grid {...args} />
+  </Grid>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  column: 3,
+  children: <div style={{ height: '100vh', backgroundColor: 'white' }}>hi</div>,
+};

--- a/src/components/common/Grid/Grid.styles.tsx
+++ b/src/components/common/Grid/Grid.styles.tsx
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+interface ContainerProps {
+  $column: number;
+}
+
+export const Container = styled.div<ContainerProps>`
+  grid-column: auto / span ${({ $column }) => $column || 1};
+`;

--- a/src/components/common/Grid/Grid.tsx
+++ b/src/components/common/Grid/Grid.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from 'react';
+
+import * as S from './Grid.styles';
+import GridContainer from './GridContainer';
+
+export interface GridProps {
+  container?: boolean;
+  column?: number;
+  children?: ReactNode;
+}
+
+const Grid: React.FC<GridProps> = (props) => {
+  const { container, column = 12, children } = props;
+
+  if (container) {
+    return <GridContainer>{children}</GridContainer>;
+  }
+
+  return <S.Container $column={column}>{children}</S.Container>;
+};
+
+export default Grid;

--- a/src/components/common/Grid/GridContainer.styles.tsx
+++ b/src/components/common/Grid/GridContainer.styles.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: grid;
+  margin: 0 24px;
+
+  gap: 28px;
+  grid-template-columns: repeat(12, 1fr);
+  grid-auto-flow: column dense;
+`;

--- a/src/components/common/Grid/GridContainer.tsx
+++ b/src/components/common/Grid/GridContainer.tsx
@@ -1,0 +1,14 @@
+import React, { ReactNode } from 'react';
+
+import * as S from './GridContainer.styles';
+
+export interface GridContainerProps {
+  children: ReactNode;
+}
+
+const GridContainer: React.FC<GridContainerProps> = (props) => {
+  const { children } = props;
+  return <S.Container>{children}</S.Container>;
+};
+
+export default GridContainer;

--- a/src/components/common/Grid/index.tsx
+++ b/src/components/common/Grid/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './Grid';
+export * from './Grid';


### PR DESCRIPTION
close #36 

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 📝 작업 내용
<!-- 작업 내용 -->

- Grid 컴포넌트 구현
  - DefaultLayout 컴포넌트가 바로 예제가 될 듯 합니다.
  - 아래의 방식처럼, container 옵션을 가진 Grid 컴포넌트 아래에 각각 column 속성을 필요한 만큼 가진 Grid 컴포넌트가 구성을 이룹니다.
 ```jsx
<Grid container>
  <Grid column={1}>내용</Grid>
  <Grdi column={3}>내용</Grid>
</Grid>
```

- DefaultLayout 컴포넌트 구현
  - side, main props를 통해 각 위치에 필요한 컴포넌트를 주입합니다.
  - [vue의 slot](https://vuejs.org/guide/components/slots.html#slot-content-and-outlet)같은 걸 구현하고 싶기는 했는데,,, 쉽지 않네요. 추후 수정할 수 있다면 해보겠습니다.

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

