### PR TITLE
[feat] SideMenu 구현

### DIFF
--- a/src/components/SideMenu/SideMenu.stories.tsx
+++ b/src/components/SideMenu/SideMenu.stories.tsx
@@ -1,0 +1,13 @@
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+
+import SideMenu from '.';
+
+export default {
+  component: SideMenu,
+  title: 'Components/SideMenu/SideMenu',
+};
+
+const Template: ComponentStory<typeof SideMenu> = (args) => <SideMenu {...args} />;
+
+export const Default = Template.bind({});

--- a/src/components/SideMenu/SideMenu.styles.tsx
+++ b/src/components/SideMenu/SideMenu.styles.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+import theme from '@src/styles/theme';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 12px;
+
+  width: 227px;
+`;
+
+export const Tags = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 8px 20px;
+  gap: 10px;
+`;
+
+export const TagTitle = styled.div`
+  padding: 15px 4px;
+
+  font-size: ${theme.textSize.T1};
+  font-weight: ${theme.fontWeight.bold};
+  line-height: ${theme.lineHeight.H};
+`;

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+import { IconNameType } from '../common/Icon/Icon';
+import TagList from '../common/TagList';
+import * as S from './SideMenu.styles';
+import SideMenuItem from './SideMenuItem';
+
+const CATEGORY_DATA: { id: number; text: string; icon: IconNameType }[] = [
+  { id: 0, text: '추천', icon: 'ThumbsUp' },
+  { id: 1, text: '커리어 생활', icon: 'Career' },
+  { id: 2, text: '개발', icon: 'Computer' },
+  { id: 3, text: '디자인', icon: 'Paint' },
+  { id: 4, text: '기획', icon: 'Paper' },
+];
+
+const TAGS = ['인기태그', '최고태그', '태그', '뭔태그', '그태그', '사랑해요', 'yapp'];
+
+const SideMenu: React.FC = () => {
+  const [selectedId, setSelectedId] = useState(0);
+
+  const handleClick = (id: number) => {
+    setSelectedId(id);
+  };
+
+  return (
+    <S.Container>
+      {CATEGORY_DATA.map((category) => (
+        <SideMenuItem key={category.id} {...category} selected={selectedId === category.id} onClick={handleClick} />
+      ))}
+      <S.Tags>
+        <S.TagTitle>인기태그</S.TagTitle>
+        <TagList tags={TAGS} />
+      </S.Tags>
+    </S.Container>
+  );
+};
+
+export default SideMenu;

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 
-import { IconNameType } from '../common/Icon/Icon';
-import TagList from '../common/TagList';
+import { IconNameType } from '@src/components/common/Icon/Icon';
+import TagList from '@src/components/common/TagList';
+
 import * as S from './SideMenu.styles';
 import SideMenuItem from './SideMenuItem';
 

--- a/src/components/SideMenu/SideMenuItem/SideMenuItem.stories.tsx
+++ b/src/components/SideMenu/SideMenuItem/SideMenuItem.stories.tsx
@@ -1,0 +1,28 @@
+import { ComponentStory } from '@storybook/react';
+import React from 'react';
+
+import SideMenuItem from '.';
+
+export default {
+  component: SideMenuItem,
+  title: 'Components/SideMenu/SideMenuItem',
+};
+
+const Template: ComponentStory<typeof SideMenuItem> = (args) => <SideMenuItem {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  text: 'text',
+};
+
+export const Icon = Template.bind({});
+Icon.args = {
+  text: '추천',
+  icon: 'ThumbsUp',
+};
+
+export const Selected = Template.bind({});
+Selected.args = {
+  text: 'text',
+  selected: true,
+};

--- a/src/components/SideMenu/SideMenuItem/SideMenuItem.styles.tsx
+++ b/src/components/SideMenu/SideMenuItem/SideMenuItem.styles.tsx
@@ -1,0 +1,40 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import theme from '@src/styles/theme';
+
+interface ContainerProps {
+  $selected: boolean;
+}
+
+export const Container = styled.div<ContainerProps>`
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  gap: 4px;
+
+  width: 242px;
+  height: 53px;
+
+  font-weight: ${theme.fontWeight.bold};
+  font-size: ${theme.textSize.T1};
+  line-height: ${theme.lineHeight.H};
+  border-radius: 8px;
+
+  cursor: pointer;
+
+  ${({ $selected }) =>
+    $selected
+      ? css`
+          background: ${theme.color.G3};
+          color: ${theme.color.Primary1};
+        `
+      : css`
+          background: ${theme.color.G1};
+
+          &:hover {
+            padding: 0 32px;
+            background: ${theme.color.G3};
+          }
+        `}
+`;

--- a/src/components/SideMenu/SideMenuItem/SideMenuItem.tsx
+++ b/src/components/SideMenu/SideMenuItem/SideMenuItem.tsx
@@ -5,17 +5,18 @@ import Icon, { IconNameType } from '@src/components/common/Icon/Icon';
 import * as S from './SideMenuItem.styles';
 
 interface SideMenuItemProps {
+  id: number;
   text: string;
   icon?: IconNameType;
   selected?: boolean;
-  onClick: (value: string) => void;
+  onClick: (id: number) => void;
 }
 
 const SideMenuItem: React.FC<SideMenuItemProps> = (props: SideMenuItemProps) => {
-  const { text, icon, selected = false, onClick } = props;
+  const { id, text, icon, selected = false, onClick } = props;
 
   const handleClick = () => {
-    onClick(text);
+    onClick(id);
   };
 
   return (

--- a/src/components/SideMenu/SideMenuItem/SideMenuItem.tsx
+++ b/src/components/SideMenu/SideMenuItem/SideMenuItem.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import Icon, { IconNameType } from '@src/components/common/Icon/Icon';
+
+import * as S from './SideMenuItem.styles';
+
+interface SideMenuItemProps {
+  text: string;
+  icon?: IconNameType;
+  selected?: boolean;
+  onClick: (value: string) => void;
+}
+
+const SideMenuItem: React.FC<SideMenuItemProps> = (props: SideMenuItemProps) => {
+  const { text, icon, selected = false, onClick } = props;
+
+  const handleClick = () => {
+    onClick(text);
+  };
+
+  return (
+    <S.Container $selected={selected} onClick={handleClick}>
+      {icon && <Icon name={icon} />}
+      {text}
+    </S.Container>
+  );
+};
+
+export default SideMenuItem;

--- a/src/components/SideMenu/SideMenuItem/index.tsx
+++ b/src/components/SideMenu/SideMenuItem/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SideMenuItem';

--- a/src/components/SideMenu/index.tsx
+++ b/src/components/SideMenu/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SideMenu';


### PR DESCRIPTION
close #23 

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->
![image](https://user-images.githubusercontent.com/45786387/211167333-d0858513-1c27-46f9-9090-90040352f727.png)

## 📝 작업 내용
<!-- 작업 내용 -->

- [x] SideMenu, SideMenuItem 구현

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

- 추후 API에 따라서 get 요청 등의 바뀔 부분이 있고, `handleClick`부분도 바뀔 여지가 충만합니다.
- 낮에 최대한 빠르게 메인 페이지 구현해보도록 하겠습니다..! 글쓰기 버튼은 조금 미루더라도..!

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

