### PR TITLE
[feat] 글쓰기 버튼 메인페이지에 추가

### DIFF
--- a/src/components/main/FabButton/FabButton.styles.tsx
+++ b/src/components/main/FabButton/FabButton.styles.tsx
@@ -15,7 +15,7 @@ export const FabButton = styled.button<{ $visible: boolean }>`
   justify-content: center;
   align-items: center;
 
-  position: absolute;
+  position: fixed;
   right: 28px;
   bottom: 28px;
 

--- a/src/components/main/MainTopicList/MainTopicList.style.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.style.tsx
@@ -25,4 +25,5 @@ export const TopicsContainer = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 80px;
+  margin-top: 24px;
 `;

--- a/src/components/main/MainTopicList/MainTopicList.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.tsx
@@ -30,7 +30,7 @@ const MainTopicList: React.FC<MainTopicListProps> = (props) => {
     const observer = new IntersectionObserver(handleObserver);
 
     observer.observe(observerRef.current);
-  });
+  }, [handleObserver]);
 
   const handleWrite = () => {
     router.push('/write');

--- a/src/components/main/MainTopicList/MainTopicList.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.tsx
@@ -2,6 +2,8 @@ import { useRouter } from 'next/router';
 import React from 'react';
 
 import TopicCard from '@src/components/common/TopicCard';
+import AddButton from '@src/components/main/AddButton';
+import FabButton from '@src/components/main/FabButton';
 import Member from '@src/types/Member';
 import Topic from '@src/types/Topic';
 
@@ -16,17 +18,23 @@ const MainTopicList: React.FC<MainTopicListProps> = (props) => {
   const { member, topics } = props;
   const router = useRouter();
 
+  const handleWrite = () => {
+    router.push('/write');
+  };
+
   return (
     <>
       <S.MainTop>
         <S.Welcome>Hello {member?.nickname || 'Fingers'}!</S.Welcome>
         <S.SubText>{member?.nickname || '당신'}의 선택은 무엇인가요?</S.SubText>
       </S.MainTop>
+      <AddButton onClick={handleWrite} />
       <S.TopicsContainer>
         {topics.map((topic) => (
           <TopicCard key={topic.id} {...topic} type="feed" badge="참여율 TOP" onClick={() => router.push('/topic/1')} />
         ))}
       </S.TopicsContainer>
+      <FabButton onClick={handleWrite} visible />
     </>
   );
 };

--- a/src/components/main/MainTopicList/MainTopicList.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import TopicCard from '@src/components/common/TopicCard';
 import AddButton from '@src/components/main/AddButton';
@@ -16,7 +16,21 @@ export interface MainTopicListProps {
 
 const MainTopicList: React.FC<MainTopicListProps> = (props) => {
   const { member, topics } = props;
+  const [fabVisible, setFabVisible] = useState<boolean>(false);
+  const observerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
+
+  const handleObserver: IntersectionObserverCallback = useCallback(
+    ([target]: IntersectionObserverEntry[]) => setFabVisible(!target.isIntersecting),
+    [],
+  );
+
+  useEffect(() => {
+    if (!observerRef.current) return;
+    const observer = new IntersectionObserver(handleObserver);
+
+    observer.observe(observerRef.current);
+  });
 
   const handleWrite = () => {
     router.push('/write');
@@ -26,6 +40,7 @@ const MainTopicList: React.FC<MainTopicListProps> = (props) => {
     <>
       <S.MainTop>
         <S.Welcome>Hello {member?.nickname || 'Fingers'}!</S.Welcome>
+        <div ref={observerRef} />
         <S.SubText>{member?.nickname || '당신'}의 선택은 무엇인가요?</S.SubText>
       </S.MainTop>
       <AddButton onClick={handleWrite} />
@@ -34,7 +49,7 @@ const MainTopicList: React.FC<MainTopicListProps> = (props) => {
           <TopicCard key={topic.id} {...topic} type="feed" badge="참여율 TOP" onClick={() => router.push('/topic/1')} />
         ))}
       </S.TopicsContainer>
-      <FabButton onClick={handleWrite} visible />
+      <FabButton onClick={handleWrite} visible={fabVisible} />
     </>
   );
 };


### PR DESCRIPTION
close #34 

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- 메인 페이지에 버튼 두개를 추가했습니다.
- FAB 버튼은 내렸을 때 나옵니다.

## 📝 작업
<!-- 작업 내용 -->
<img width="925" alt="스크린샷 2023-01-13 11 37 25" src="https://user-images.githubusercontent.com/45786387/212224392-6555169c-5653-4119-8222-5aa70408793b.png">

- 딱 요정도 내렸을 때 Fab버튼이 노출됩니다.

<img width="1084" alt="스크린샷 2023-01-13 11 37 40" src="https://user-images.githubusercontent.com/45786387/212224418-5fdd577b-952e-4645-95ae-5957b5ce0dbb.png">

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

- 아직 인기글 캐러셀이 없어서 위에 토픽이 하나 없습니다.
- 캐러셀 추가 시 observer div 위치 조정해야합니다.

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

