### PR TITLE
[feat] 메인 페이지 레이아웃 구현

### DIFF
--- a/src/components/common/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/common/TopicCard/SelectOption/SelectOption.tsx
@@ -17,6 +17,7 @@ const SelectOption = (props: SelectOptionProps) => {
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
+    e.nativeEvent.preventDefault();
     onClick(id, selected);
   };
 

--- a/src/components/common/TopicCard/TopicCard.tsx
+++ b/src/components/common/TopicCard/TopicCard.tsx
@@ -100,4 +100,4 @@ const TopicCard = (props: TopicCardProps) => {
   );
 };
 
-export default TopicCard;
+export default React.forwardRef(TopicCard);

--- a/src/components/common/TopicCard/TopicCard.tsx
+++ b/src/components/common/TopicCard/TopicCard.tsx
@@ -14,7 +14,7 @@ interface TopicCardProps extends Topic {
   onClick?: () => void;
 }
 
-const TopicCard = (props: TopicCardProps) => {
+const TopicCard = (props: TopicCardProps, ref: React.ForwardedRef<HTMLDivElement>) => {
   const { title, contents, options: defaultOptions, member, comments, badge, type, onClick } = props;
   const [options, setOptions] = useState<TopicOption[]>(defaultOptions);
   const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null); // TODO: 초기 선택 여부 확인해야함
@@ -44,7 +44,7 @@ const TopicCard = (props: TopicCardProps) => {
   };
 
   return (
-    <S.Container onClick={onClick}>
+    <S.Container onClick={onClick} ref={ref}>
       <S.TopicTop>
         <S.TopicHeader>
           <div>
@@ -100,4 +100,4 @@ const TopicCard = (props: TopicCardProps) => {
   );
 };
 
-export default React.forwardRef(TopicCard);
+export default React.forwardRef<HTMLDivElement, TopicCardProps>(TopicCard);

--- a/src/components/main/Main/Main.stories.tsx
+++ b/src/components/main/Main/Main.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { TOPICS } from '@mocks/data/topics';
+
+import Main from '.';
+
+export default {
+  title: 'main/Main',
+  component: Main,
+} as ComponentMeta<typeof Main>;
+
+const Template: ComponentStory<typeof Main> = (args) => <Main {...args} />;
+
+export const 기본 = Template.bind({});
+기본.args = {
+  popularTopics: TOPICS,
+  topics: TOPICS,
+};

--- a/src/components/main/Main/Main.styles.tsx
+++ b/src/components/main/Main/Main.styles.tsx
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+export const Observer = styled.div`
+  margin-bottom: 80px;
+  height: 20px;
+`;

--- a/src/components/main/Main/Main.tsx
+++ b/src/components/main/Main/Main.tsx
@@ -1,0 +1,52 @@
+import { useRouter } from 'next/router';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import AddButton from '@src/components/main/AddButton';
+import FabButton from '@src/components/main/FabButton';
+import MainTopicList from '@src/components/main/MainTopicList';
+import TopicCarousel from '@src/components/main/TopicCarousel';
+import Member from '@src/types/Member';
+import Topic from '@src/types/Topic';
+
+import * as S from './Main.styles';
+
+export interface MainProps {
+  member?: Member;
+  popularTopics: Topic[];
+  topics: Topic[];
+}
+
+const Main: React.FC<MainProps> = (props) => {
+  const { member, popularTopics, topics } = props;
+  const [fabVisible, setFabVisible] = useState<boolean>(false);
+  const observerRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  const handleObserver: IntersectionObserverCallback = useCallback(
+    ([target]: IntersectionObserverEntry[]) => setFabVisible(!target.isIntersecting),
+    [],
+  );
+
+  useEffect(() => {
+    if (!observerRef.current) return;
+    const observer = new IntersectionObserver(handleObserver);
+
+    observer.observe(observerRef.current);
+  }, [handleObserver]);
+
+  const handleWrite = () => {
+    router.push('/write');
+  };
+
+  return (
+    <>
+      <TopicCarousel member={member} topics={popularTopics} />
+      <S.Observer ref={observerRef} />
+      <AddButton onClick={handleWrite} />
+      <MainTopicList topics={topics} />
+      <FabButton onClick={handleWrite} visible={fabVisible} />
+    </>
+  );
+};
+
+export default Main;

--- a/src/components/main/Main/index.tsx
+++ b/src/components/main/Main/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Main';

--- a/src/components/main/MainTopicList/MainTopicList.style.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.style.tsx
@@ -1,25 +1,5 @@
 import styled from '@emotion/styled';
 
-import theme from '@src/styles/theme';
-
-export const MainTop = styled.div`
-  margin-bottom: 24px;
-  height: 62px;
-
-  color: ${theme.color.G8};
-`;
-
-export const Welcome = styled.div`
-  font-size: 28px;
-  line-height: 34px;
-  font-family: ${theme.fontFamily.english};
-`;
-
-export const SubText = styled.div`
-  font-size: ${theme.textSize.B1};
-  line-height: ${theme.lineHeight.B};
-`;
-
 export const TopicsContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/components/main/MainTopicList/MainTopicList.style.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.style.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 export const TopicsContainer = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   gap: 80px;
   margin-top: 24px;
 `;

--- a/src/components/main/MainTopicList/MainTopicList.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.tsx
@@ -1,9 +1,7 @@
 import { useRouter } from 'next/router';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React from 'react';
 
 import TopicCard from '@src/components/common/TopicCard';
-import AddButton from '@src/components/main/AddButton';
-import FabButton from '@src/components/main/FabButton';
 import Member from '@src/types/Member';
 import Topic from '@src/types/Topic';
 
@@ -15,42 +13,15 @@ export interface MainTopicListProps {
 }
 
 const MainTopicList: React.FC<MainTopicListProps> = (props) => {
-  const { member, topics } = props;
-  const [fabVisible, setFabVisible] = useState<boolean>(false);
-  const observerRef = useRef<HTMLDivElement>(null);
+  const { topics } = props;
   const router = useRouter();
 
-  const handleObserver: IntersectionObserverCallback = useCallback(
-    ([target]: IntersectionObserverEntry[]) => setFabVisible(!target.isIntersecting),
-    [],
-  );
-
-  useEffect(() => {
-    if (!observerRef.current) return;
-    const observer = new IntersectionObserver(handleObserver);
-
-    observer.observe(observerRef.current);
-  }, [handleObserver]);
-
-  const handleWrite = () => {
-    router.push('/write');
-  };
-
   return (
-    <>
-      <S.MainTop>
-        <S.Welcome>Hello {member?.nickname || 'Fingers'}!</S.Welcome>
-        <div ref={observerRef} />
-        <S.SubText>{member?.nickname || '당신'}의 선택은 무엇인가요?</S.SubText>
-      </S.MainTop>
-      <AddButton onClick={handleWrite} />
-      <S.TopicsContainer>
-        {topics.map((topic) => (
-          <TopicCard key={topic.id} {...topic} type="feed" badge="참여율 TOP" onClick={() => router.push('/topic/1')} />
-        ))}
-      </S.TopicsContainer>
-      <FabButton onClick={handleWrite} visible={fabVisible} />
-    </>
+    <S.TopicsContainer>
+      {topics.map((topic) => (
+        <TopicCard key={topic.id} {...topic} type="feed" onClick={() => router.push('/topic/1')} />
+      ))}
+    </S.TopicsContainer>
   );
 };
 

--- a/src/components/main/MainTopicList/MainTopicList.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 import React from 'react';
 
 import TopicCard from '@src/components/common/TopicCard';
@@ -14,12 +14,13 @@ export interface MainTopicListProps {
 
 const MainTopicList: React.FC<MainTopicListProps> = (props) => {
   const { topics } = props;
-  const router = useRouter();
 
   return (
     <S.TopicsContainer>
       {topics.map((topic) => (
-        <TopicCard key={topic.id} {...topic} type="feed" onClick={() => router.push('/topic/1')} />
+        <Link key={topic.id} href={`/topic/${topic.id}`} passHref>
+          <TopicCard {...topic} type="feed" />
+        </Link>
       ))}
     </S.TopicsContainer>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,14 +4,14 @@ import { MEMBER } from '@mocks/data/member';
 import { TOPICS } from '@mocks/data/topics';
 
 import DefaultLayout from '@src/components/common/DefaultLayout';
-import MainTopicList from '@src/components/main/MainTopicList';
+import Main from '@src/components/main/Main';
 import SideMenu from '@src/components/main/SideMenu';
 
 const Home: NextPage = () => {
   return (
     <DefaultLayout //
       side={<SideMenu />}
-      main={<MainTopicList member={MEMBER} topics={TOPICS} />}
+      main={<Main member={MEMBER} popularTopics={TOPICS} topics={TOPICS} />}
     />
   );
 };

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -54,3 +54,15 @@ p {
   font-size: 14pt;
   font-weight: regular;
 }
+
+a {
+  color: #fff;
+  text-decoration: none;
+  outline: none;
+}
+a:hover,
+a:active {
+  text-decoration: none;
+  color: #fff;
+  background-color: #f59000;
+}

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -55,14 +55,10 @@ p {
   font-weight: regular;
 }
 
-a {
-  color: #fff;
-  text-decoration: none;
-  outline: none;
-}
+a,
 a:hover,
 a:active {
+  color: inherit;
   text-decoration: none;
-  color: #fff;
-  background-color: #f59000;
+  outline: none;
 }


### PR DESCRIPTION
close #35 

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

<img width="1225" alt="스크린샷 2023-01-19 10 44 28" src="https://user-images.githubusercontent.com/45786387/213336034-793a5c6e-d088-4c2c-b5aa-73286644acfe.png">

- 메인페이지 레이아웃 구현

## 📝 작업 내용
<!-- 작업 내용 -->

- MainTopicList가 리스트만 담당하도록 변경
- Main 컴포넌트를 만들어 TopicCarousel, MainTopicList, AddButton, FabButton을 포함하고 랜더링할 수 있도록 변경
- onClick으로 route하지 않고 Link 컴포넌트로 route될 수 있도록 변경

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

