### PR TITLE
[feat] 커먼성 TextArea 컴포넌트 구현

### DIFF
--- a/src/components/common/TextArea/TextArea.stories.tsx
+++ b/src/components/common/TextArea/TextArea.stories.tsx
@@ -1,0 +1,55 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ChangeEvent, useState } from 'react';
+
+import TextArea from '.';
+
+export default {
+  title: 'common/TextArea',
+  component: TextArea,
+  argTypes: {},
+} as ComponentMeta<typeof TextArea>;
+
+const Template: ComponentStory<typeof TextArea> = (args) => {
+  const [value, setValue] = useState('');
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+  };
+
+  return <TextArea {...args} value={value} onChange={handleChange} />;
+};
+
+export const 기본 = Template.bind({});
+기본.args = {
+  placeholder: 'placeholder',
+};
+
+export const 카운트 = Template.bind({});
+카운트.args = {
+  placeholder: 'placeholder',
+  maxLength: 20,
+};
+
+export const row = Template.bind({});
+row.args = {
+  placeholder: 'placeholder',
+  maxLength: 20,
+  rows: 5,
+};
+
+export const withLabel = Template.bind({});
+withLabel.args = {
+  id: 'label',
+  placeholder: '라벨을 선택하세요',
+  maxLength: 20,
+};
+withLabel.decorators = [
+  (Story) => {
+    return (
+      <div>
+        <label htmlFor="label">라벨</label>
+        <Story htmlId="label" />
+      </div>
+    );
+  },
+];

--- a/src/components/common/TextArea/TextArea.styles.tsx
+++ b/src/components/common/TextArea/TextArea.styles.tsx
@@ -1,0 +1,60 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import theme from '@src/styles/theme';
+
+export const Wrapper = styled.div<{ $isTyped: boolean }>`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  background-color: ${theme.color.G3};
+  border: 1px solid ${theme.color.G5};
+  border-radius: 8px;
+  &:focus-within {
+    border-color: ${theme.color.G6};
+  }
+  ${({ $isTyped }) =>
+    $isTyped &&
+    css`
+      border-color: ${theme.color.G6};
+    `}
+`;
+
+export const TextAreaWrapper = styled.div`
+  padding: 20px;
+`;
+
+export const TextArea = styled.textarea`
+  outline: none;
+  background-color: transparent;
+  width: 100%;
+  resize: none;
+  border: none;
+  font-size: ${theme.textSize.B2};
+  line-height: ${theme.lineHeight.B};
+  font-family: ${theme.fontFamily.basic};
+  caret-color: ${theme.color.Primary1};
+  color: ${theme.color.G8};
+  &::placeholder {
+    color: ${theme.color.G6};
+  }
+  &:focus {
+    outline: none;
+  }
+`;
+
+export const TextLengthWrpper = styled.div`
+  padding: 12px 20px;
+  display: flex;
+  justify-content: flex-end;
+  font-size: ${theme.textSize.B3};
+  line-height: ${theme.lineHeight.B};
+`;
+
+export const TextLength = styled.span`
+  color: ${theme.color.G6};
+`;
+
+export const CurrentText = styled.span`
+  color: ${theme.color.G7};
+`;

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -1,0 +1,37 @@
+import { ChangeEvent, FC, TextareaHTMLAttributes } from 'react';
+
+import * as S from './TextArea.styles';
+
+interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  value: string;
+  onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+const TextArea: FC<Props> = (props) => {
+  const { value, onChange, maxLength, ...rest } = props;
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    if (maxLength && e.target.value.length > maxLength) return;
+
+    onChange(e);
+  };
+
+  const isTyped = !!value;
+
+  return (
+    <S.Wrapper $isTyped={isTyped}>
+      <S.TextAreaWrapper>
+        <S.TextArea {...rest} value={value} onChange={handleChange} maxLength={maxLength} />
+      </S.TextAreaWrapper>
+      {maxLength && (
+        <S.TextLengthWrpper>
+          <S.TextLength>
+            (<S.CurrentText>{value.length}</S.CurrentText>/{maxLength})
+          </S.TextLength>
+        </S.TextLengthWrpper>
+      )}
+    </S.Wrapper>
+  );
+};
+
+export default TextArea;

--- a/src/components/common/TextArea/index.ts
+++ b/src/components/common/TextArea/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TextArea';


### PR DESCRIPTION
close #55 

## 💡 개요
<img width="827" alt="TextArea 구현 이미지" src="https://user-images.githubusercontent.com/45627868/213395696-c134d824-5c68-4ebb-bffd-9d4f7ea1a077.png">


## 📝 작업 내용
- [x] textArea 컴포넌트 구현
- [x] 카운트 기능 구현 (확장성을 위해 optional로 받기)

## ‼️ 주의 사항
- 디자인을 보면 해당 컴포넌트는 count 형태만 존재하지만, 후에 확장성을 위해 maxLength 여부에 따라 count UI 와 그렇지 않은 UI 로 구분하였습니다. 

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

