### PR TITLE
[feat] 메인 페이지 api 적용

### DIFF
--- a/__mocks__/apis/handlers/index.ts
+++ b/__mocks__/apis/handlers/index.ts
@@ -1,3 +1,5 @@
+import { memberHandler } from '@mocks/apis/handlers/member';
+
 import { authHandler } from './auth';
 import { commentHandler } from './comment';
 import { topicDetailHandler } from './topic';
@@ -6,4 +8,5 @@ export const handlers = [
   ...authHandler, //
   ...topicDetailHandler,
   ...commentHandler,
+  ...memberHandler,
 ];

--- a/__mocks__/apis/handlers/member.ts
+++ b/__mocks__/apis/handlers/member.ts
@@ -1,0 +1,21 @@
+import { ResponseComposition, RestContext, RestRequest, rest } from 'msw';
+
+import { MEMBER } from '@mocks/data/member';
+
+import { GetProfileResponse } from '@src/apis';
+import { BASE_URL } from '@src/configs/axios';
+
+const getProfile = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
+  return res(
+    ctx.status(200),
+    ctx.json<GetProfileResponse>({
+      code: 'SUCCESS',
+      message: '성공',
+      data: MEMBER,
+    }),
+  );
+};
+
+export const memberHandler = [
+  rest.get(`${BASE_URL}/profile`, getProfile), //
+];

--- a/__mocks__/apis/handlers/topic.ts
+++ b/__mocks__/apis/handlers/topic.ts
@@ -1,10 +1,9 @@
 import { ResponseComposition, RestContext, RestRequest, rest } from 'msw';
 
-import { TOPICS, TOPIC_DETAIL } from '@mocks/data/topic';
+import { POPULAR_TOPICS, TOPICS, TOPIC_DETAIL } from '@mocks/data/topic';
 
-import { BaseResponse, GetTopicsResponse, GetTopicsResponseData } from '@src/apis/';
+import { GetPopularTopicsResponse, GetTopicDetailResponse, GetTopicsResponse, GetTopicsResponseData } from '@src/apis/';
 import { BASE_URL } from '@src/configs/axios';
-import Topic from '@src/types/Topic';
 
 const getTopics = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
   const lastOffset = req.url.searchParams.get('lastOffset');
@@ -29,10 +28,21 @@ const getTopics = (req: RestRequest, res: ResponseComposition, ctx: RestContext)
   );
 };
 
+const getPopularTopics = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
+  return res(
+    ctx.status(200),
+    ctx.json<GetPopularTopicsResponse>({
+      code: 'SUCCESS',
+      message: '성공',
+      data: POPULAR_TOPICS,
+    }),
+  );
+};
+
 const getTopic = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
   return res(
     ctx.status(200),
-    ctx.json<BaseResponse<Topic>>({
+    ctx.json<GetTopicDetailResponse>({
       code: 'SUCCESS',
       message: '성공',
       data: TOPIC_DETAIL,
@@ -42,5 +52,6 @@ const getTopic = (req: RestRequest, res: ResponseComposition, ctx: RestContext) 
 
 export const topicDetailHandler = [
   rest.get(`${BASE_URL}/topic/latest`, getTopics),
+  rest.get(`${BASE_URL}/topic/popular`, getPopularTopics),
   rest.get(`${BASE_URL}/topic/:topicId`, getTopic),
 ];

--- a/__mocks__/apis/handlers/topic.ts
+++ b/__mocks__/apis/handlers/topic.ts
@@ -2,7 +2,7 @@ import { ResponseComposition, RestContext, RestRequest, rest } from 'msw';
 
 import { POPULAR_TOPICS, TOPICS, TOPIC_DETAIL } from '@mocks/data/topic';
 
-import { GetPopularTopicsResponse, GetTopicDetailResponse, GetTopicsResponse, GetTopicsResponseData } from '@src/apis/';
+import { GetPopularTopicsResponse, GetTopicDetailResponse, GetTopicsResponse, GetTopicsResponseData } from '@src/apis';
 import { BASE_URL } from '@src/configs/axios';
 
 const getTopics = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {

--- a/__mocks__/apis/handlers/topic.ts
+++ b/__mocks__/apis/handlers/topic.ts
@@ -1,22 +1,46 @@
 import { ResponseComposition, RestContext, RestRequest, rest } from 'msw';
 
-import { TOPIC } from '@mocks/data/topic';
+import { TOPICS, TOPIC_DETAIL } from '@mocks/data/topic';
 
-import { BaseResponse } from '@src/apis/';
+import { BaseResponse, GetTopicsResponse, GetTopicsResponseData } from '@src/apis/';
 import { BASE_URL } from '@src/configs/axios';
 import Topic from '@src/types/Topic';
+
+const getTopics = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
+  const lastOffset = req.url.searchParams.get('lastOffset');
+
+  const responseData: GetTopicsResponseData[] = [];
+  if (lastOffset === null) {
+    responseData.push(...TOPICS.slice(0, 5));
+  } else {
+    const index = TOPICS.findIndex((topic) => topic.topicId === +lastOffset);
+    responseData.push(...TOPICS.slice(index + 1, index + 1 + 5));
+  }
+
+  return res(
+    ctx.status(200),
+    ctx.json<GetTopicsResponse>({
+      code: 'SUCCESS',
+      message: '성공',
+      data: responseData,
+      hasNext: !!responseData.length,
+      offsetId: responseData.length ? responseData[responseData.length - 1].topicId : null,
+    }),
+  );
+};
 
 const getTopic = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
   return res(
     ctx.status(200),
     ctx.json<BaseResponse<Topic>>({
-      code: 'SUCCES',
+      code: 'SUCCESS',
       message: '성공',
-      data: TOPIC,
+      data: TOPIC_DETAIL,
     }),
   );
 };
 
 export const topicDetailHandler = [
-  rest.get(`${BASE_URL}/topic/:topicId`, getTopic), //
+  rest.get(`${BASE_URL}/topic/latest`, getTopics),
+  rest.get(`${BASE_URL}/topic/:topicId`, getTopic),
 ];

--- a/__mocks__/data/topic.ts
+++ b/__mocks__/data/topic.ts
@@ -1,7 +1,7 @@
 import { MEMBER } from '@mocks/data/member';
 import { VOTE_OPTIONS } from '@mocks/data/voteOption';
 
-import { GetTopicsResponseData } from '@src/apis';
+import { GetPopularTopicsResponseData, GetTopicsResponseData } from '@src/apis';
 import Topic from '@src/types/Topic';
 
 export const TOPIC: GetTopicsResponseData = {
@@ -35,6 +35,24 @@ export const TOPICS: GetTopicsResponseData[] = [
   { ...TOPIC, topicId: 17, title: '17' },
   { ...TOPIC, topicId: 18, title: '18' },
   { ...TOPIC, topicId: 19, title: '19' },
+];
+
+export const POPULAR_TOPIC: GetTopicsResponseData = {
+  topicId: 1,
+  title: 'Vote1',
+  contents: 'Content1',
+  member: MEMBER,
+  commentAmount: 2,
+  voteAmount: 0,
+  tags: [],
+  voteOptions: VOTE_OPTIONS,
+};
+
+export const POPULAR_TOPICS: GetPopularTopicsResponseData[] = [
+  POPULAR_TOPIC,
+  { ...POPULAR_TOPIC, topicId: 2, title: '두번째' },
+  { ...POPULAR_TOPIC, topicId: 3, title: '세번째' },
+  { ...POPULAR_TOPIC, topicId: 4, title: '네번째' },
 ];
 
 export const TOPIC_DETAIL: Topic = {

--- a/__mocks__/data/topic.ts
+++ b/__mocks__/data/topic.ts
@@ -1,27 +1,44 @@
 import { MEMBER } from '@mocks/data/member';
 import { VOTE_OPTIONS } from '@mocks/data/voteOption';
 
+import { GetTopicsResponseData } from '@src/apis';
 import Topic from '@src/types/Topic';
 
-export const TOPIC: Topic = {
+export const TOPIC: GetTopicsResponseData = {
   topicId: 1,
   title: 'Vote1',
   contents: 'Content1',
   member: MEMBER,
   commentAmount: 2,
   voteAmount: 0,
-  liked: false,
-  likeAmount: 0,
   tags: [],
   voteOptions: VOTE_OPTIONS,
 };
 
-export const TOPICS: Topic[] = [
+export const TOPICS: GetTopicsResponseData[] = [
   { ...TOPIC },
-  { ...TOPIC, topicId: 1, title: '두번째' },
-  { ...TOPIC, topicId: 2, title: '세번째' },
-  { ...TOPIC, topicId: 3, title: '네번째' },
-  { ...TOPIC, topicId: 4, title: '다섯번째' },
-  { ...TOPIC, topicId: 5, title: '여섯번째' },
-  { ...TOPIC, topicId: 6, title: '일곱번째' },
+  { ...TOPIC, topicId: 2, title: '두번째' },
+  { ...TOPIC, topicId: 3, title: '세번째' },
+  { ...TOPIC, topicId: 4, title: '네번째' },
+  { ...TOPIC, topicId: 5, title: '다섯번째' },
+  { ...TOPIC, topicId: 6, title: '여섯번째' },
+  { ...TOPIC, topicId: 7, title: '일곱번째' },
+  { ...TOPIC, topicId: 8, title: '8' },
+  { ...TOPIC, topicId: 9, title: '9' },
+  { ...TOPIC, topicId: 10, title: '10' },
+  { ...TOPIC, topicId: 11, title: '11' },
+  { ...TOPIC, topicId: 12, title: '12' },
+  { ...TOPIC, topicId: 13, title: '13' },
+  { ...TOPIC, topicId: 14, title: '14' },
+  { ...TOPIC, topicId: 15, title: '15' },
+  { ...TOPIC, topicId: 16, title: '16' },
+  { ...TOPIC, topicId: 17, title: '17' },
+  { ...TOPIC, topicId: 18, title: '18' },
+  { ...TOPIC, topicId: 19, title: '19' },
 ];
+
+export const TOPIC_DETAIL: Topic = {
+  ...TOPIC,
+  liked: false,
+  likeAmount: 0,
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,6 +1,7 @@
 export * from './topic';
 export * from './comment';
 export * from './auth';
+export * from './member';
 
 export interface BaseResponse<T> {
   message: string;

--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -3,8 +3,7 @@ import axios from 'axios';
 import { BaseResponse } from '@src/apis/index';
 import Member from '@src/types/Member';
 
-export type GetProfileResponseData = Pick<Member, 'nickname' | 'profileImage'>;
-export type GetProfileResponse = BaseResponse<GetProfileResponseData>;
+export type GetProfileResponse = BaseResponse<Member>;
 
 export const getProfile = async (token: string) => {
   const res = await axios.get<GetProfileResponse>('/profile', {

--- a/src/apis/member.ts
+++ b/src/apis/member.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+import { BaseResponse } from '@src/apis/index';
+import Member from '@src/types/Member';
+
+export type GetProfileResponseData = Pick<Member, 'nickname' | 'profileImage'>;
+export type GetProfileResponse = BaseResponse<GetProfileResponseData>;
+
+export const getProfile = async (token: string) => {
+  const res = await axios.get<GetProfileResponse>('/profile', {
+    headers: {
+      Authorization: token,
+    },
+  });
+
+  return res.data;
+};

--- a/src/apis/topic.ts
+++ b/src/apis/topic.ts
@@ -25,3 +25,11 @@ export const getTopics = async (offsetId?: number) => {
 
   return res.data;
 };
+
+export type GetPopularTopicsResponseData = Omit<Topic, 'liked' | 'likeAmount'>;
+export type GetPopularTopicsResponse = BaseResponse<GetPopularTopicsResponseData[]>;
+export const getPopularTopics = async () => {
+  const res = await axios.get<GetPopularTopicsResponse>('/topic/popular');
+
+  return res.data.data;
+};

--- a/src/apis/topic.ts
+++ b/src/apis/topic.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import Topic from '@src/types/Topic';
 
-import { BaseResponse } from './';
+import { BasePaginationResponse, BaseResponse } from './';
 
 /**
  * 토픽 상세 조회
@@ -13,4 +13,15 @@ export const getTopicDetail = async (topicId: number) => {
   const res = await axios.get<GetTopicDetailResponse>(`/topic/${topicId}`);
 
   return res.data.data;
+};
+
+export type GetTopicsResponseData = Omit<Topic, 'liked' | 'likeAmount'>;
+export type GetTopicsResponse = BasePaginationResponse<GetTopicsResponseData[]>;
+
+export const getTopics = async (offsetId?: number) => {
+  const queries = new URLSearchParams({ lastOffset: offsetId?.toString() || '' });
+  const url = `/topic/latest?${queries.toString()}`;
+  const res = await axios.get<GetTopicsResponse>(url);
+
+  return res.data;
 };

--- a/src/components/common/Header/Header.stories.tsx
+++ b/src/components/common/Header/Header.stories.tsx
@@ -22,11 +22,8 @@ export const 로그인 = Template.bind({});
     <RecoilRoot
       initializeState={({ set }) => {
         set($userSession, {
-          isMember: true,
-          jwtTokens: {
-            accessToken: 'access-token',
-            refreshToken: 'refresh-token',
-          },
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
         });
       }}
     >

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue, useResetRecoilState } from 'recoil';
 
 import Icon from '@src/components/common/Icon';
 import UserInfo from '@src/components/common/UserInfo';
+import useProfile from '@src/queires/useProfile';
 import $userSession from '@src/recoil/userSession';
 
 import * as S from './Header.style';
@@ -11,10 +12,9 @@ import UserMenu from './UserMenu';
 
 const Header: FC = () => {
   const userSession = useRecoilValue($userSession);
+  const { data: member } = useProfile(userSession?.accessToken || '');
   const resetUser = useResetRecoilState($userSession);
   const [viewUserMenu, setViewUserMenu] = useState(false);
-
-  const isLogin = !!userSession;
 
   const handleLogout = () => {
     resetUser();
@@ -32,9 +32,9 @@ const Header: FC = () => {
           <S.Menu>
             <Icon name="Search" size={30} />
           </S.Menu>
-          {isLogin ? (
+          {member ? (
             <S.UserInfoWrapper onClick={() => setViewUserMenu((prev) => !prev)}>
-              <UserInfo type="simple" />
+              <UserInfo type="simple" member={member} />
             </S.UserInfoWrapper>
           ) : (
             <Link href="/login">

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -42,9 +42,9 @@ const Header: FC = () => {
             </Link>
           )}
         </S.Menus>
-        {viewUserMenu && (
+        {member && viewUserMenu && (
           <S.UserMenuWrapper>
-            <UserMenu onLogout={handleLogout} />
+            <UserMenu member={member} onLogout={handleLogout} />
           </S.UserMenuWrapper>
         )}
       </S.HeaderContents>

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -12,7 +12,7 @@ import UserMenu from './UserMenu';
 
 const Header: FC = () => {
   const userSession = useRecoilValue($userSession);
-  const { data: member } = useProfile(userSession?.accessToken || '');
+  const { data: member } = useProfile(userSession?.accessToken);
   const resetUser = useResetRecoilState($userSession);
   const [viewUserMenu, setViewUserMenu] = useState(false);
 

--- a/src/components/common/Header/UserMenu/UserMenu.stories.tsx
+++ b/src/components/common/Header/UserMenu/UserMenu.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import { MEMBER } from '@mocks/data/member';
+
 import UserMenu from './UserMenu';
 
 export default {
@@ -11,4 +13,6 @@ export default {
 const Template: ComponentStory<typeof UserMenu> = ({ ...args }) => <UserMenu {...args} />;
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  member: MEMBER,
+};

--- a/src/components/common/Header/UserMenu/UserMenu.tsx
+++ b/src/components/common/Header/UserMenu/UserMenu.tsx
@@ -2,19 +2,21 @@ import React, { FC } from 'react';
 
 import Icon from '@src/components/common/Icon';
 import UserInfo from '@src/components/common/UserInfo';
+import Member from '@src/types/Member';
 
 import * as S from './UserMenu.styles';
 
 interface Props {
+  member: Member;
   onLogout: () => void;
 }
 const UserMenu: FC<Props> = (props) => {
-  const { onLogout } = props;
+  const { member, onLogout } = props;
 
   return (
     <S.Wrapper>
       <S.UserItem>
-        <UserInfo />
+        <UserInfo member={member} />
         <Icon name="ArrowRight" size={24} />
       </S.UserItem>
       <S.MenuItem>문의하기</S.MenuItem>

--- a/src/components/common/UserInfo/UserInfo.stories.tsx
+++ b/src/components/common/UserInfo/UserInfo.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import { MEMBER } from '@mocks/data/member';
+
 import UserInfo from './UserInfo';
 
 export default {
@@ -13,9 +15,11 @@ const Template: ComponentStory<typeof UserInfo> = ({ ...args }) => <UserInfo {..
 export const simple = Template.bind({});
 simple.args = {
   type: 'simple',
+  member: MEMBER,
 };
 
 export const full = Template.bind({});
 full.args = {
   type: 'full',
+  member: MEMBER,
 };

--- a/src/components/common/UserInfo/UserInfo.tsx
+++ b/src/components/common/UserInfo/UserInfo.tsx
@@ -2,8 +2,8 @@ import React, { FC } from 'react';
 
 import { MEMBER } from '@mocks/data/member';
 
-import { Member } from '@src/apis';
 import DefaultImage from '@src/assets/user-default.png';
+import Member from '@src/types/Member';
 
 import * as S from './UserInfo.styles';
 
@@ -16,15 +16,15 @@ interface Props {
 
 const UserInfo: FC<Props> = (props) => {
   const { type = 'full', member = MEMBER } = props;
+  const { nickname, jobCategory, workingYears, profileImage } = member;
 
   const size = type === 'full' ? 44 : 28;
 
-  const { name, jobCategory, workingYears, profileImage } = member;
   return (
     <S.Wrapper>
-      <S.Profile src={profileImage ?? DefaultImage} alt={name} width={size} height={size} />
+      <S.Profile src={profileImage ?? DefaultImage} alt={nickname} width={size} height={size} />
       <S.SummaryWrapper>
-        <S.UserNickName>{name}</S.UserNickName>
+        <S.UserNickName>{nickname}</S.UserNickName>
         {type === 'full' && (
           <S.UserInfo>
             {jobCategory}·{workingYears}년차

--- a/src/components/common/UserInfo/UserInfo.tsx
+++ b/src/components/common/UserInfo/UserInfo.tsx
@@ -11,11 +11,11 @@ import * as S from './UserInfo.styles';
 // 우선 Member 의 MockData 로 처리
 interface Props {
   type?: 'simple' | 'full';
-  member?: Member;
+  member: Member;
 }
 
 const UserInfo: FC<Props> = (props) => {
-  const { type = 'full', member = MEMBER } = props;
+  const { type = 'full', member } = props;
   const { nickname, jobCategory, workingYears, profileImage } = member;
 
   const size = type === 'full' ? 44 : 28;

--- a/src/components/main/Main/Main.tsx
+++ b/src/components/main/Main/Main.tsx
@@ -1,23 +1,22 @@
 import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import { GetTopicsResponseData } from '@src/apis';
 import AddButton from '@src/components/main/AddButton';
 import FabButton from '@src/components/main/FabButton';
 import MainTopicList from '@src/components/main/MainTopicList';
 import TopicCarousel from '@src/components/main/TopicCarousel';
 import Member from '@src/types/Member';
-import Topic from '@src/types/Topic';
 
 import * as S from './Main.styles';
 
 export interface MainProps {
   member?: Member;
-  popularTopics: Topic[];
-  topics: Topic[];
+  popularTopics: GetTopicsResponseData[];
 }
 
 const Main: React.FC<MainProps> = (props) => {
-  const { member, popularTopics, topics } = props;
+  const { member, popularTopics } = props;
   const [fabVisible, setFabVisible] = useState<boolean>(false);
   const observerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
@@ -43,7 +42,7 @@ const Main: React.FC<MainProps> = (props) => {
       <TopicCarousel member={member} topics={popularTopics} />
       <S.Observer ref={observerRef} />
       <AddButton onClick={handleWrite} />
-      <MainTopicList topics={topics} />
+      <MainTopicList />
       <FabButton onClick={handleWrite} visible={fabVisible} />
     </>
   );

--- a/src/components/main/Main/Main.tsx
+++ b/src/components/main/Main/Main.tsx
@@ -6,17 +6,15 @@ import AddButton from '@src/components/main/AddButton';
 import FabButton from '@src/components/main/FabButton';
 import MainTopicList from '@src/components/main/MainTopicList';
 import TopicCarousel from '@src/components/main/TopicCarousel';
-import Member from '@src/types/Member';
 
 import * as S from './Main.styles';
 
 export interface MainProps {
-  member?: Member;
   popularTopics: GetTopicsResponseData[];
 }
 
 const Main: React.FC<MainProps> = (props) => {
-  const { member, popularTopics } = props;
+  const { popularTopics } = props;
   const [fabVisible, setFabVisible] = useState<boolean>(false);
   const observerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
@@ -39,7 +37,7 @@ const Main: React.FC<MainProps> = (props) => {
 
   return (
     <>
-      <TopicCarousel member={member} topics={popularTopics} />
+      <TopicCarousel topics={popularTopics} />
       <S.Observer ref={observerRef} />
       <AddButton onClick={handleWrite} />
       <MainTopicList />

--- a/src/components/main/MainTopicList/MainTopicList.tsx
+++ b/src/components/main/MainTopicList/MainTopicList.tsx
@@ -1,19 +1,24 @@
 import Link from 'next/link';
 import React from 'react';
+import { useInView } from 'react-intersection-observer';
 
 import TopicCard from '@src/components/common/TopicCard';
-import Member from '@src/types/Member';
-import Topic from '@src/types/Topic';
+import { useGetTopics } from '@src/queires/useGetTopics';
 
 import * as S from './MainTopicList.style';
 
-export interface MainTopicListProps {
-  member?: Member;
-  topics: Topic[];
-}
+const MainTopicList: React.FC = () => {
+  const { fetchNextPage, data: topics = [], isLoading, hasNextPage } = useGetTopics();
 
-const MainTopicList: React.FC<MainTopicListProps> = (props) => {
-  const { topics } = props;
+  const { ref } = useInView({
+    onChange: (inView) => {
+      if (inView && hasNextPage) {
+        fetchNextPage();
+      }
+    },
+  });
+
+  if (isLoading) return null;
 
   return (
     <S.TopicsContainer>
@@ -22,6 +27,7 @@ const MainTopicList: React.FC<MainTopicListProps> = (props) => {
           <TopicCard {...topic} type="feed" />
         </Link>
       ))}
+      <div ref={ref} />
     </S.TopicsContainer>
   );
 };

--- a/src/components/main/TopicCarousel/TopicCarousel.tsx
+++ b/src/components/main/TopicCarousel/TopicCarousel.tsx
@@ -2,23 +2,27 @@
 import { css } from '@emotion/react';
 import Link from 'next/link';
 import React, { useCallback, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { GetTopicsResponseData } from '@src/apis';
 import Icon from '@src/components/common/Icon';
 import TopicCard from '@src/components/common/TopicCard';
-import Member from '@src/types/Member';
+import useProfile from '@src/queires/useProfile';
+import $userSession from '@src/recoil/userSession';
 
 import * as S from './TopicCarousel.styles';
 
 interface TopicCarouselProps {
   topics: GetTopicsResponseData[];
-  member?: Member;
 }
 
 const TRANSITION = 'all 0.5s ease-in-out';
 
 const TopicCarousel: React.FC<TopicCarouselProps> = (props: TopicCarouselProps) => {
-  const { topics, member } = props;
+  const { topics } = props;
+  const tokens = useRecoilValue($userSession);
+  const { data: member } = useProfile(tokens?.accessToken || '');
+
   const carouselTopics = [{ ...topics[topics.length - 1], topicId: -1 }, ...topics, { ...topics[0], topicId: -2 }];
   const [current, setCurrent] = useState<number>(1);
   const [displayCurrent, setDisplayCurrent] = useState<number>(1);

--- a/src/components/main/TopicCarousel/TopicCarousel.tsx
+++ b/src/components/main/TopicCarousel/TopicCarousel.tsx
@@ -21,7 +21,7 @@ const TRANSITION = 'all 0.5s ease-in-out';
 const TopicCarousel: React.FC<TopicCarouselProps> = (props: TopicCarouselProps) => {
   const { topics } = props;
   const tokens = useRecoilValue($userSession);
-  const { data: member } = useProfile(tokens?.accessToken || '');
+  const { data: member } = useProfile(tokens?.accessToken);
 
   const carouselTopics = [{ ...topics[topics.length - 1], topicId: -1 }, ...topics, { ...topics[0], topicId: -2 }];
   const [current, setCurrent] = useState<number>(1);

--- a/src/components/main/TopicCarousel/TopicCarousel.tsx
+++ b/src/components/main/TopicCarousel/TopicCarousel.tsx
@@ -3,15 +3,15 @@ import { css } from '@emotion/react';
 import Link from 'next/link';
 import React, { useCallback, useState } from 'react';
 
+import { GetTopicsResponseData } from '@src/apis';
 import Icon from '@src/components/common/Icon';
 import TopicCard from '@src/components/common/TopicCard';
 import Member from '@src/types/Member';
-import Topic from '@src/types/Topic';
 
 import * as S from './TopicCarousel.styles';
 
 interface TopicCarouselProps {
-  topics: Topic[];
+  topics: GetTopicsResponseData[];
   member?: Member;
 }
 

--- a/src/components/main/TopicCarousel/TopicCarousel.tsx
+++ b/src/components/main/TopicCarousel/TopicCarousel.tsx
@@ -19,7 +19,7 @@ const TRANSITION = 'all 0.5s ease-in-out';
 
 const TopicCarousel: React.FC<TopicCarouselProps> = (props: TopicCarouselProps) => {
   const { topics, member } = props;
-  const carouselTopics = [topics[topics.length - 1], ...topics, topics[0]];
+  const carouselTopics = [{ ...topics[topics.length - 1], topicId: -1 }, ...topics, { ...topics[0], topicId: -2 }];
   const [current, setCurrent] = useState<number>(1);
   const [displayCurrent, setDisplayCurrent] = useState<number>(1);
   const [transition, setTransition] = useState<string>(TRANSITION);

--- a/src/components/topic/TopicDetailMain/TopicDetailMain.stories.tsx
+++ b/src/components/topic/TopicDetailMain/TopicDetailMain.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import { TOPIC } from '@mocks/data/topic';
+import { TOPIC_DETAIL } from '@mocks/data/topic';
 
 import TopicDetailMain from '.';
 
@@ -14,7 +14,7 @@ const Template: ComponentStory<typeof TopicDetailMain> = ({ ...args }) => <Topic
 
 export const Default = Template.bind({});
 Default.args = {
-  topic: TOPIC,
+  topic: TOPIC_DETAIL,
 };
 Default.decorators = [
   (Story, context) => (

--- a/src/pages/auth.ts
+++ b/src/pages/auth.ts
@@ -24,7 +24,7 @@ const Auth = () => {
         // 이미 가입된 유저로 홈으로 이동
         // 로그인 성공
         // user 상태 관리!
-        setUserSession(result);
+        setUserSession(result.jwtTokens);
 
         router.push('/');
       } else {

--- a/src/pages/index.stories.tsx
+++ b/src/pages/index.stories.tsx
@@ -1,6 +1,8 @@
 import { ComponentStory } from '@storybook/react';
 import React from 'react';
 
+import { POPULAR_TOPICS } from '@mocks/data/topic';
+
 import Home from '.';
 
 export default {
@@ -11,3 +13,6 @@ export default {
 const Template: ComponentStory<typeof Home> = (args) => <Home {...args} />;
 
 export const Default = Template.bind({});
+Default.args = {
+  popularTopics: POPULAR_TOPICS,
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ const Home: NextPage = () => {
   return (
     <DefaultLayout //
       side={<SideMenu />}
-      main={<Main member={MEMBER} popularTopics={TOPICS} topics={TOPICS} />}
+      main={<Main member={MEMBER} popularTopics={TOPICS} />}
     />
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,6 @@
 import type { NextPage } from 'next';
 import { GetServerSideProps } from 'next';
 
-import { MEMBER } from '@mocks/data/member';
-
 import { GetPopularTopicsResponseData, getPopularTopics } from '@src/apis';
 import DefaultLayout from '@src/components/common/DefaultLayout';
 import Main from '@src/components/main/Main';
@@ -16,7 +14,7 @@ const Home: NextPage<HomeProps> = ({ popularTopics }) => {
   return (
     <DefaultLayout //
       side={<SideMenu />}
-      main={<Main member={MEMBER} popularTopics={popularTopics} />}
+      main={<Main popularTopics={popularTopics} />}
     />
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,30 @@
 import type { NextPage } from 'next';
+import { GetServerSideProps } from 'next';
 
 import { MEMBER } from '@mocks/data/member';
-import { TOPICS } from '@mocks/data/topic';
 
+import { GetPopularTopicsResponseData, getPopularTopics } from '@src/apis';
 import DefaultLayout from '@src/components/common/DefaultLayout';
 import Main from '@src/components/main/Main';
 import SideMenu from '@src/components/main/SideMenu';
 
-const Home: NextPage = () => {
+interface HomeProps {
+  popularTopics: GetPopularTopicsResponseData[];
+}
+
+const Home: NextPage<HomeProps> = ({ popularTopics }) => {
   return (
     <DefaultLayout //
       side={<SideMenu />}
-      main={<Main member={MEMBER} popularTopics={TOPICS} />}
+      main={<Main member={MEMBER} popularTopics={popularTopics} />}
     />
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const popularTopics = await getPopularTopics();
+
+  return { props: { popularTopics } };
 };
 
 export default Home;

--- a/src/pages/topic/[id].stories.tsx
+++ b/src/pages/topic/[id].stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import { TOPIC } from '@mocks/data/topic';
+import { TOPIC_DETAIL } from '@mocks/data/topic';
 
 import TopicDetail from './[id]';
 
@@ -14,7 +14,7 @@ const Template: ComponentStory<typeof TopicDetail> = ({ ...args }) => <TopicDeta
 
 export const Default = Template.bind({});
 Default.args = {
-  topicDetail: TOPIC,
+  topicDetail: TOPIC_DETAIL,
 };
 Default.parameters = {
   nextRouter: {

--- a/src/queires/constant.ts
+++ b/src/queires/constant.ts
@@ -1,4 +1,5 @@
 export const queryKeys = {
   topic: 'topic',
+  topics: 'topics',
   comment: 'comment',
 };

--- a/src/queires/constant.ts
+++ b/src/queires/constant.ts
@@ -2,4 +2,5 @@ export const queryKeys = {
   topic: 'topic',
   topics: 'topics',
   comment: 'comment',
+  profile: 'profile',
 };

--- a/src/queires/useGetTopics.ts
+++ b/src/queires/useGetTopics.ts
@@ -1,0 +1,24 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { GetTopicsResponse, getTopics } from '@src/apis';
+
+import { queryKeys } from './constant';
+
+export const useGetTopics = () => {
+  const result = useInfiniteQuery<GetTopicsResponse>([queryKeys.topics], ({ pageParam }) => getTopics(pageParam), {
+    getNextPageParam: (lastPage) => lastPage.offsetId ?? undefined,
+  });
+
+  const { data } = result;
+
+  const topics = data
+    ? data.pages
+        .map((page) => page.data)
+        .reduce((mergedContents, currentContents) => [...(mergedContents || []), ...(currentContents || [])], [])
+    : [];
+
+  return {
+    ...result,
+    data: topics,
+  };
+};

--- a/src/queires/useProfile.ts
+++ b/src/queires/useProfile.ts
@@ -3,8 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 import { GetProfileResponse, getProfile } from '@src/apis';
 import { queryKeys } from '@src/queires/constant';
 
-const useProfile = (token: string) => {
-  const result = useQuery<GetProfileResponse>([queryKeys.profile, token], () => getProfile(token));
+const useProfile = (token = '') => {
+  const result = useQuery<GetProfileResponse>([queryKeys.profile, token], () => getProfile(token), {
+    enabled: !!token,
+  });
 
   return {
     ...result,

--- a/src/queires/useProfile.ts
+++ b/src/queires/useProfile.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { GetProfileResponse, getProfile } from '@src/apis';
+import { queryKeys } from '@src/queires/constant';
+
+const useProfile = (token: string) => {
+  const result = useQuery<GetProfileResponse>([queryKeys.profile, token], () => getProfile(token));
+
+  return {
+    ...result,
+    data: result.data?.data,
+  };
+};
+
+export default useProfile;

--- a/src/recoil/userSession.ts
+++ b/src/recoil/userSession.ts
@@ -6,8 +6,8 @@ import { Auth } from '@src/apis/auth';
 
 import localStorageEffect from './effects/localstorageEffect';
 
-const $userSession = atom<Auth | undefined>({
-  key: 'user-sesseion',
+const $userSession = atom<Auth['jwtTokens'] | undefined>({
+  key: 'user-session',
   default: undefined,
   effects: [localStorageEffect('user')],
 });


### PR DESCRIPTION
close #69 

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- 인기 토픽 목록, 최신 토픽 목록에 대한 api 적용
- msw 로만 확인함

## 📝 작업 내용
<!-- 작업 내용 -->

- mockData 내에서 리스트를 위한 `TOPIC`과 `TOPIC_DETAIL`을 구분
- 토픽 목록 조회 및 무한 스크롤 구현 
- 인기 토픽 목록 조회 및 ssr적용
- 유저의 정보를 가져오는 `useProfile` 구현
  - 헤더에도 `useProfile` 적용

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

- `useProfile`은 오로지 msw 위에서만 작동합니다.
- `$userSession`의 스펙을 조금 변경했습니다.
  - `isMember`는 초기 로그인 이후에 필요 없다고 판단해 토큰들만 저장하도록 바꿨습니다.
- 나중에 토큰의 관리 방식이나, api에 따라서 바뀔 수도 있겠습니다. 하지만 크게 바뀌진 않을 거라고 예상...만.... 많은 의견 부탁드립니다!

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

승규님의 기존 코드를 거의 그대로 가져왔습니다 👍🏼 개꿀이었습니다 👍🏼 