### PR TITLE
[feat] api에 맞게 codeBlock 형태 변경

### DIFF
--- a/__mocks__/data/voteOption.ts
+++ b/__mocks__/data/voteOption.ts
@@ -6,6 +6,7 @@ export const VOTE_OPTION: VoteOption = {
   voteOptionId: 1,
   text: 'Content1 OptionA',
   image: null,
+  language: null,
   codeBlock: null,
   voted: false,
   voteAmount: 1,
@@ -26,9 +27,7 @@ export const VOTE_OPTION_WITH_IMAGE: VoteOption = {
   image: TEST_IMAGE,
 };
 
-export const CODE_BLOCK: VoteOption['codeBlock'] = {
-  language: 'js',
-  contents: `
+export const CODE_BLOCK: VoteOption['codeBlock'] = `
 import React, { MouseEvent } from 'react';
 
 import { Languages } from '@src/components/common/CodeEditor';
@@ -74,12 +73,12 @@ const SelectOption = (props: SelectOptionProps) => {
 };
 
 export default SelectOption;
-    `,
-};
+`;
 
 export const VOTE_OPTION_WITH_CODE: VoteOption = {
   ...VOTE_OPTION,
   voteOptionId: 9,
   text: '코드가 있어요!',
+  language: 'javascript',
   codeBlock: CODE_BLOCK,
 };

--- a/src/apis/topic.ts
+++ b/src/apis/topic.ts
@@ -36,11 +36,10 @@ export const getPopularTopics = async () => {
 };
 
 export interface PostTopicRequest extends Pick<Topic, 'title' | 'contents' | 'tags'> {
-  voteOptions: Pick<VoteOption, 'text' | 'image' | 'codeBlock'>[];
+  voteOptions: Pick<VoteOption, 'text' | 'image' | 'language' | 'codeBlock'>[];
   topicCategory: TopicCategory;
 }
 
 export const createTopic = (data: PostTopicRequest) => {
   return axios.post('/topic', data);
 };
-

--- a/src/components/common/CodeEditor/CodeEditor.stories.tsx
+++ b/src/components/common/CodeEditor/CodeEditor.stories.tsx
@@ -15,6 +15,6 @@ const Template: ComponentStory<typeof CodeEditor> = (args) => <CodeEditor {...ar
 export const Default = Template.bind({});
 Default.args = {
   language: 'javascript',
-  value: CODE_BLOCK?.contents,
+  value: CODE_BLOCK as string,
   disabled: false,
 };

--- a/src/components/common/CodeEditor/CodeEditor.tsx
+++ b/src/components/common/CodeEditor/CodeEditor.tsx
@@ -11,7 +11,7 @@ const TextAreaCodeEditor = dynamic(() => import('@uiw/react-textarea-code-editor
 });
 
 export interface CodeEditorProps extends TextareaCodeEditorProps {
-  value: string;
+  value?: string;
   language: Languages;
   onChangeLanguage?: (language: Languages) => void;
 }

--- a/src/components/common/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/common/TopicCard/SelectOption/SelectOption.tsx
@@ -14,7 +14,7 @@ interface SelectOptionProps extends VoteOption {
 }
 
 const SelectOption = (props: SelectOptionProps) => {
-  const { voteOptionId, text, rate = 0, result = false, selected = false, image, codeBlock, onClick } = props;
+  const { voteOptionId, text, rate = 0, result = false, selected = false, image, language, codeBlock, onClick } = props;
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
@@ -39,7 +39,7 @@ const SelectOption = (props: SelectOptionProps) => {
       )}
       {codeBlock && (
         <S.CodeBlockWrapper>
-          <CodeEditor language={codeBlock.language as Languages} value={codeBlock.contents} disabled />
+          <CodeEditor language={language || 'javascript'} value={codeBlock} disabled />
           <S.CodeBlockGradiant />
         </S.CodeBlockWrapper>
       )}

--- a/src/components/write/WriteMain/VoteOptionInputs/VoteOptionInputs.tsx
+++ b/src/components/write/WriteMain/VoteOptionInputs/VoteOptionInputs.tsx
@@ -49,11 +49,7 @@ const VoteOptionInputs: React.FC<VoteOptionInputsProps> = (props) => {
   const handleChangeCodeLanguage = (targetId: number) => (language: Languages) => {
     const changed = [...options];
     const index = options.findIndex(({ id }) => id === targetId);
-    const target = changed[index].codeBlock;
-    changed[index].codeBlock = {
-      language,
-      contents: target?.contents || '',
-    };
+    changed[index].language = language;
     setOptions(changed);
   };
 
@@ -61,11 +57,7 @@ const VoteOptionInputs: React.FC<VoteOptionInputsProps> = (props) => {
     const { value } = event.target;
     const index = options.findIndex(({ id }) => id === targetId);
     const changed = [...options];
-    const target = changed[index].codeBlock;
-    changed[index].codeBlock = {
-      language: target?.language || 'javascript',
-      contents: value,
-    };
+    changed[index].codeBlock = value;
     setOptions(changed);
   };
 
@@ -97,37 +89,39 @@ const VoteOptionInputs: React.FC<VoteOptionInputsProps> = (props) => {
         ))}
       </PS.ButtonContainer>
       <S.OptionsContainer>
-        {(selected === 'text' ? options : options.slice(0, 2)).map(({ id, text, image, codeBlock }, index) => (
-          <React.Fragment key={id}>
-            <S.Label>
-              <S.LabelText>항목{index + 1}</S.LabelText>
-              <Input placeholder="항목을 입력해주세요." value={text} maxLength={20} onChange={handleChangeText(id)} />
-              {selected === 'text' && options.length > 2 && (
-                <S.DeleteBtn onClick={handleDeleteOption(id)}>
-                  <Icon name="X" color="G8" size={18} />
-                </S.DeleteBtn>
+        {(selected === 'text' ? options : options.slice(0, 2)).map(
+          ({ id, text, image, language, codeBlock }, index) => (
+            <React.Fragment key={id}>
+              <S.Label>
+                <S.LabelText>항목{index + 1}</S.LabelText>
+                <Input placeholder="항목을 입력해주세요." value={text} maxLength={20} onChange={handleChangeText(id)} />
+                {selected === 'text' && options.length > 2 && (
+                  <S.DeleteBtn onClick={handleDeleteOption(id)}>
+                    <Icon name="X" color="G8" size={18} />
+                  </S.DeleteBtn>
+                )}
+              </S.Label>
+              {selected.includes('code') && (
+                <S.CodeEditorWrapper>
+                  <CodeEditor
+                    value={codeBlock || ''}
+                    language={language || 'javascript'}
+                    onChangeLanguage={handleChangeCodeLanguage(id)}
+                    onChange={handleChangeCode(id)}
+                  />
+                </S.CodeEditorWrapper>
               )}
-            </S.Label>
-            {selected.includes('code') && (
-              <S.CodeEditorWrapper>
-                <CodeEditor
-                  value={codeBlock?.contents || ''}
-                  language={codeBlock?.language || 'javascript'}
-                  onChangeLanguage={handleChangeCodeLanguage(id)}
-                  onChange={handleChangeCode(id)}
-                />
-              </S.CodeEditorWrapper>
-            )}
-            {selected.includes('img') && (
-              <S.ImgSelectorWrapper>
-                <ImgSelector onChange={handleUploadImg(index)}>
-                  <Icon name="Image" />
-                </ImgSelector>
-                {image && <S.SelectedImage src={image} alt="vote option image" width={232} height={180} />}
-              </S.ImgSelectorWrapper>
-            )}
-          </React.Fragment>
-        ))}
+              {selected.includes('img') && (
+                <S.ImgSelectorWrapper>
+                  <ImgSelector onChange={handleUploadImg(index)}>
+                    <Icon name="Image" />
+                  </ImgSelector>
+                  {image && <S.SelectedImage src={image} alt="vote option image" width={232} height={180} />}
+                </S.ImgSelectorWrapper>
+              )}
+            </React.Fragment>
+          ),
+        )}
         {selected === 'text' && options.length < 4 && <S.AddOption onClick={handleAddOption}>+ 항목 추가</S.AddOption>}
       </S.OptionsContainer>
     </PS.Section>

--- a/src/types/VoteOption.ts
+++ b/src/types/VoteOption.ts
@@ -4,10 +4,8 @@ export default interface VoteOption {
   voteOptionId: number;
   text: string;
   image?: string | null;
-  codeBlock?: {
-    language: Languages;
-    contents: string;
-  } | null;
+  language?: Languages | null;
+  codeBlock?: string | null;
   voted: boolean;
   voteAmount: number;
 }


### PR DESCRIPTION
close #81

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- api 변경에 따른 `voteOption.codeBlock` 변경

## 📝 작업 내용
<!-- 작업 내용 -->

```ts
export default interface VoteOption {
  voteOptionId: number;
  text: string;
  image?: string | null;
  language?: Languages | null;
  codeBlock?: string | null;
  voted: boolean;
  voteAmount: number;
}
```
- 사용 중인 곳 변경

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

