### PR TITLE
[feat] 구글 oauth 과정 동안 loading UI 적용

### DIFF
--- a/src/components/common/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner/LoadingSpinner.tsx
@@ -8,8 +8,8 @@ interface Props {
   /**
    * hex값 string 또는 color string(red, blue, ...)
    */
-  color: string;
-  size: number;
+  color?: string;
+  size?: number;
 }
 const LoadingSpinner: FC<Props> = (props) => {
   const { color = theme.color.Primary1, size = 50 } = props;

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 
+import LoadingSpinner from '@src/components/common/LoadingSpinner';
 import { useSignin } from '@src/queires/useSignin';
 import $userSession from '@src/recoil/userSession';
 
@@ -24,8 +25,14 @@ const Auth = () => {
           router.push(`/onboarding?code=${result?.jwtTokens.accessToken}`, '/onboarding');
         }
       },
+      onError: (error) => {
+        // GYU-TODO: 로그인 실패인 경우 UI 구현해야함!
+        console.log('error handling', error);
+      },
     });
   }, [code, router, setUserSession, signin]);
+
+  return <LoadingSpinner />;
 };
 
 export default Auth;


### PR DESCRIPTION
close #91 

## 💡 개요
<img width="685" alt="스크린샷 2023-02-11 오후 11 53 25" src="https://user-images.githubusercontent.com/45627868/218265256-aba0725f-fd44-4dcb-a056-c5b072d40d67.png">
- oauth 과정 동안 로딩 화면 적용

## 📝 작업 내용
- [x] 구글 로그인 중이면 loading UI 적용

## ‼️ 주의 사항
- 현재 배포 작업 완료가 안되어서 vercel 관련된 것은 에러가 납니다!

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

