### PR TITLE
[feat] 투표하기 기능 api 추가

### DIFF
--- a/__mocks__/apis/handlers/index.ts
+++ b/__mocks__/apis/handlers/index.ts
@@ -3,10 +3,12 @@ import { memberHandler } from '@mocks/apis/handlers/member';
 import { authHandler } from './auth';
 import { commentHandler } from './comment';
 import { topicDetailHandler } from './topic';
+import voteHandler from './vote';
 
 export const handlers = [
   ...authHandler, //
   ...topicDetailHandler,
   ...commentHandler,
   ...memberHandler,
+  ...voteHandler,
 ];

--- a/__mocks__/apis/handlers/topic.ts
+++ b/__mocks__/apis/handlers/topic.ts
@@ -2,7 +2,13 @@ import { ResponseComposition, RestContext, RestRequest, rest } from 'msw';
 
 import { POPULAR_TOPICS, TOPICS, TOPIC_DETAIL } from '@mocks/data/topic';
 
-import { GetPopularTopicsResponse, GetTopicDetailResponse, GetTopicsResponse, GetTopicsResponseData, PostTopicRequest } from '@src/apis';
+import {
+  GetPopularTopicsResponse,
+  GetTopicDetailResponse,
+  GetTopicsResponse,
+  GetTopicsResponseData,
+  PostTopicRequest,
+} from '@src/apis';
 import { BASE_URL } from '@src/configs/axios';
 
 const getTopics = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {

--- a/__mocks__/apis/handlers/vote.ts
+++ b/__mocks__/apis/handlers/vote.ts
@@ -9,6 +9,6 @@ const vote = (req: RestRequest<VoteRequest>, res: ResponseComposition, ctx: Rest
 
 const voteHandler = [
   rest.post(`${BASE_URL}/vote/option`, vote), //
-] as const;
+];
 
 export default voteHandler;

--- a/__mocks__/apis/handlers/vote.ts
+++ b/__mocks__/apis/handlers/vote.ts
@@ -1,0 +1,14 @@
+import { ResponseComposition, RestContext, RestRequest, rest } from 'msw';
+
+import { VoteRequest } from '@src/apis';
+import { BASE_URL } from '@src/configs/axios';
+
+const vote = (req: RestRequest<VoteRequest>, res: ResponseComposition, ctx: RestContext) => {
+  return res(ctx.status(200));
+};
+
+const voteHandler = [
+  rest.post(`${BASE_URL}/vote/option`, vote), //
+] as const;
+
+export default voteHandler;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -2,6 +2,7 @@ export * from './topic';
 export * from './comment';
 export * from './auth';
 export * from './member';
+export * from './vote';
 
 export interface ErrorResponse {
   code: string;

--- a/src/apis/vote.ts
+++ b/src/apis/vote.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+import Topic from '@src/types/Topic';
+import VoteOption from '@src/types/VoteOption';
+
+export interface VoteRequest {
+  topicId: Topic['topicId'];
+  voteOptionId: VoteOption['voteOptionId'];
+}
+
+export const vote = (data: VoteRequest) => {
+  return axios.post('/vote/option', data);
+};

--- a/src/components/common/TopicCard/SelectOption/SelectOption.tsx
+++ b/src/components/common/TopicCard/SelectOption/SelectOption.tsx
@@ -1,6 +1,6 @@
 import React, { MouseEvent } from 'react';
 
-import CodeEditor, { Languages } from '@src/components/common/CodeEditor';
+import CodeEditor from '@src/components/common/CodeEditor';
 import Icon from '@src/components/common/Icon';
 import VoteOption from '@src/types/VoteOption';
 

--- a/src/components/common/TopicCard/TopicCard.stories.tsx
+++ b/src/components/common/TopicCard/TopicCard.stories.tsx
@@ -21,6 +21,7 @@ const Template: ComponentStory<typeof TopicCard> = (args) => <TopicCard {...args
 
 export const Default = Template.bind({});
 Default.args = {
+  topicId: 1,
   title: 'Title',
   contents: 'contents',
   voteOptions: VOTE_OPTIONS,

--- a/src/components/common/TopicCard/TopicCard.tsx
+++ b/src/components/common/TopicCard/TopicCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import ProfileImg from '@src/components/common/ProfileImg';
 import ShareIcon from '@src/components/common/ShareIcon';
+import { useVote } from '@src/queires/useVote';
 import Topic from '@src/types/Topic';
 import VoteOption from '@src/types/VoteOption';
 
@@ -19,6 +20,8 @@ interface TopicCardProps extends Omit<Topic, 'liked' | 'likeAmount' | 'tags'> {
 
 const TopicCard = (props: TopicCardProps, ref: React.ForwardedRef<HTMLDivElement>) => {
   const { topicId, title, contents, voteOptions: defaultOptions, member, commentAmount, badge, type, onClick } = props;
+  const { vote } = useVote();
+
   const [options, setOptions] = useState<VoteOption[]>(defaultOptions);
   const selectedOption = options.find((option) => option.voted);
   const [selectedOptionId, setSelectedOptionId] = useState<number | null>(selectedOption?.voteOptionId || null);
@@ -26,25 +29,28 @@ const TopicCard = (props: TopicCardProps, ref: React.ForwardedRef<HTMLDivElement
 
   const isFeed = type === 'feed';
 
-  const handleClickOption = (id: number) => {
+  const handleClickOption = (voteOptionId: number) => {
     const changed = options.map((option) => {
       if (option.voteOptionId === selectedOptionId) {
         option.voteAmount -= 1;
         return option;
       }
-      if (option.voteOptionId === id) {
+      if (option.voteOptionId === voteOptionId) {
         option.voteAmount += 1;
       }
       return option;
     });
     setOptions(changed);
-    setSelectedOptionId(id);
+    setSelectedOptionId(voteOptionId);
 
-    if (selectedOptionId === id) {
+    if (selectedOptionId === voteOptionId) {
       setSelectedOptionId(null);
     }
 
-    // TODO: api
+    vote({
+      topicId,
+      voteOptionId,
+    });
   };
 
   return (

--- a/src/queires/useVote.ts
+++ b/src/queires/useVote.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { VoteRequest, vote } from '@src/apis';
+
+export const useVote = () => {
+  const mutation = useMutation((data: VoteRequest) => vote(data));
+
+  return {
+    ...mutation,
+    vote: mutation.mutate,
+  };
+};

--- a/src/queires/useVote.ts
+++ b/src/queires/useVote.ts
@@ -7,6 +7,6 @@ export const useVote = () => {
 
   return {
     ...mutation,
-    vote: mutation.mutate,
+    vote: mutation.mutateAsync,
   };
 };


### PR DESCRIPTION
close #94

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- `/vote/option` api를 연결 

## 📝 작업 내용
<!-- 작업 내용 -->

- voteOption 클릭 시 api 실행
- 토큰 없을 때 alert 후 로그인 화면으로 이동
- 유효하지 않은 토큰이라 401 발생 시 alert 후 로그인 화면으로 이동
- 관련 msw 작성

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

- 추후 로그인 화면으로 이동하는 로직 커스텀훅으로 빼도 될지도?

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

