### PR TITLE
[feat] 토픽 상세 페이지에서 로그인 여부에 따른 기능 동작 구현

### DIFF
--- a/src/components/topic/CommentForm/CommentForm.styles.tsx
+++ b/src/components/topic/CommentForm/CommentForm.styles.tsx
@@ -2,12 +2,13 @@ import styled from '@emotion/styled';
 
 import theme from '@src/styles/theme';
 
-export const Form = styled.form`
+export const Form = styled.form<{ $disabled: boolean }>`
   border: 1px solid ${theme.color.G4};
   border-radius: 8px;
   background: ${theme.color.G1};
   display: flex;
   flex-direction: column;
+  cursor: ${({ $disabled }) => $disabled && 'not-allowed'};
 `;
 
 export const TextAreaWrapper = styled.div`
@@ -22,6 +23,7 @@ export const TextArea = styled.textarea`
   caret-color: ${theme.color.Primary1};
   color: ${theme.color.borderPrimary};
   font-family: ${theme.fontFamily.basic};
+  cursor: inherit;
 
   &::placeholder {
     color: ${theme.color.txtSecondary};
@@ -49,6 +51,6 @@ export const SubmitButton = styled.button`
   &:disabled {
     background-color: ${theme.color.G4};
     border-color: ${theme.color.G4};
-    cursor: auto;
+    cursor: inherit;
   }
 `;

--- a/src/components/topic/CommentForm/CommentForm.styles.tsx
+++ b/src/components/topic/CommentForm/CommentForm.styles.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import theme from '@src/styles/theme';
@@ -8,7 +9,11 @@ export const Form = styled.form<{ $disabled: boolean }>`
   background: ${theme.color.G1};
   display: flex;
   flex-direction: column;
-  cursor: ${({ $disabled }) => $disabled && 'not-allowed'};
+  ${({ $disabled }) =>
+    $disabled &&
+    css`
+      cursor: not-allowed;
+    `}
 `;
 
 export const TextAreaWrapper = styled.div`

--- a/src/components/topic/CommentForm/CommentForm.tsx
+++ b/src/components/topic/CommentForm/CommentForm.tsx
@@ -7,9 +7,10 @@ interface Props {
   placeholder: string;
   rows?: number;
   onSubmit: (commentValue: string) => void;
+  disabled?: boolean;
 }
 const CommentForm: FC<Props> = (props) => {
-  const { placeholder, rows, onSubmit } = props;
+  const { placeholder, rows, disabled, onSubmit } = props;
 
   const [value, setValue] = useState('');
 
@@ -27,12 +28,18 @@ const CommentForm: FC<Props> = (props) => {
   };
 
   return (
-    <S.Form onSubmit={handleSubmit}>
+    <S.Form onSubmit={handleSubmit} $disabled={!!disabled}>
       <S.TextAreaWrapper>
-        <S.TextArea rows={rows ?? 3} placeholder={placeholder} value={value} onChange={handleChange} />
+        <S.TextArea
+          rows={rows ?? 3}
+          placeholder={placeholder}
+          value={value}
+          onChange={handleChange}
+          disabled={!!disabled}
+        />
       </S.TextAreaWrapper>
       <S.ButtonWrapper>
-        <S.SubmitButton disabled={!value}>등록</S.SubmitButton>
+        <S.SubmitButton disabled={!value || !!disabled}>등록</S.SubmitButton>
       </S.ButtonWrapper>
     </S.Form>
   );

--- a/src/components/topic/TopicDetailMain/TopicDetailMain.tsx
+++ b/src/components/topic/TopicDetailMain/TopicDetailMain.tsx
@@ -1,10 +1,12 @@
 import { FC } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import ShareIcon from '@src/components/common/ShareIcon';
 import TopicCard from '@src/components/common/TopicCard';
 import CommentForm from '@src/components/topic/CommentForm';
 import CommentList from '@src/components/topic/CommentList';
 import { useCreateComments } from '@src/queires/useCreateComment';
+import $userSession from '@src/recoil/userSession';
 import Topic from '@src/types/Topic';
 
 import * as S from './TopicDetailMain.styles';
@@ -17,10 +19,13 @@ const TopicDetailMain: FC<Props> = (props) => {
   const { topic } = props;
 
   const { mutateComment } = useCreateComments(topic.topicId);
+  const userSession = useRecoilValue($userSession);
 
   const handleAddComment = (commentValue: string) => {
     mutateComment.mutate(commentValue);
   };
+
+  const isLogin = !!userSession;
 
   return (
     <S.Wrapper>
@@ -30,7 +35,11 @@ const TopicDetailMain: FC<Props> = (props) => {
         </S.ShareIcon>
         <TopicCard {...topic} type="detail" />
       </S.TopicCardWrapper>
-      <CommentForm placeholder="닉네임님, 댓글을 남겨보세요! 💬" onSubmit={handleAddComment} />
+      <CommentForm
+        placeholder={isLogin ? '닉네임님, 댓글을 남겨보세요! 💬' : '유저님, 로그인하고 댓글을 남겨보세요! 💬'}
+        onSubmit={handleAddComment}
+        disabled={!isLogin}
+      />
       <CommentList />
     </S.Wrapper>
   );

--- a/src/pages/topic/[id].stories.tsx
+++ b/src/pages/topic/[id].stories.tsx
@@ -2,6 +2,8 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { TOPIC_DETAIL } from '@mocks/data/topic';
 
+import { localstorageKeys } from '@src/constants/localstorage';
+
 import TopicDetail from './[id].page';
 
 export default {
@@ -11,12 +13,7 @@ export default {
 } as ComponentMeta<typeof TopicDetail>;
 
 const Template: ComponentStory<typeof TopicDetail> = ({ ...args }) => <TopicDetail {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  topicDetail: TOPIC_DETAIL,
-};
-Default.parameters = {
+Template.parameters = {
   nextRouter: {
     path: '/topic/[id]',
     query: {
@@ -24,3 +21,25 @@ Default.parameters = {
     },
   },
 };
+
+export const 비로그인 = Template.bind({});
+비로그인.args = {
+  topicDetail: TOPIC_DETAIL,
+};
+비로그인.decorators = [
+  (Story) => {
+    localStorage.removeItem(localstorageKeys.user);
+    return <Story />;
+  },
+];
+
+export const 로그인 = Template.bind({});
+로그인.args = {
+  topicDetail: TOPIC_DETAIL,
+};
+로그인.decorators = [
+  (Story) => {
+    localStorage.setItem(localstorageKeys.user, JSON.stringify({ accessToken: 'token' }));
+    return <Story />;
+  },
+];


### PR DESCRIPTION
close #90 

## 💡 개요
![image](https://user-images.githubusercontent.com/45627868/218302122-986ad048-058e-41e4-afdf-2de10982ec6d.png)
- 로그인 여부에 따라 기능 동작 구현

## 📝 작업 내용
- msw 기반으로 구현했습니다. 다른 피쳐따서 api 연동하는 작업 추가로 진행해야합니다!
- [x] 댓글 추가 기능 구현 (msw)
- [x] 로그인 여부에 따라 plaholder 문구 및 disabled 적용 (msw)

## ‼️ 주의 사항
- 스토리북으로 로그인, 비로그인 형태를 만들었는데 해당 패턴을 모두다 적용시켜도 되는데 좀 더 좋은 방안이 없을까? 고민하다가 떠오르지 않아서 단순하게 했습니다. 좋은 방법이 있는지 고민해주시면 좋을거 같아요!!

## 🔗 참고자료


