### PR TITLE
[feat] storybook에서 localStorage 관리

### DIFF
--- a/.storybook/localStorageDecorator.ts
+++ b/.storybook/localStorageDecorator.ts
@@ -1,0 +1,11 @@
+import { DecoratorFunction } from '@storybook/addons';
+
+const localStorageDecorator: DecoratorFunction = (story, { parameters }) => {
+  localStorage.clear();
+  if (parameters && parameters.storage) {
+    Object.entries(parameters.storage).forEach(([key, value]) => localStorage.setItem(key, JSON.stringify(value)));
+  }
+  return story();
+};
+
+export default localStorageDecorator;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,12 +10,14 @@ import '@src/styles/common.css';
 
 import { handlers } from '../__mocks__/apis/handlers';
 import { initAxiosConfig, interceptorsAxiosConfig } from '../src/configs/axios';
+import localStorageDecorator from './localStorageDecorator';
 
 initialize();
 initAxiosConfig();
 interceptorsAxiosConfig();
 
 export const decorators = [
+  localStorageDecorator,
   mswDecorator,
   (Story) => (
     <RecoilRoot>

--- a/__mocks__/data/localStorage.ts
+++ b/__mocks__/data/localStorage.ts
@@ -1,0 +1,7 @@
+import { localstorageKeys } from '@src/constants/localstorage';
+
+export const LOGGED_IN = {
+  [localstorageKeys.user]: {
+    accessToken: 'token',
+  },
+};

--- a/src/pages/index.stories.tsx
+++ b/src/pages/index.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory } from '@storybook/react';
 import React from 'react';
 
+import { LOGGED_IN } from '@mocks/data/localStorage';
 import { POPULAR_TOPICS } from '@mocks/data/topic';
 
 import Home from './index.page';
@@ -15,4 +16,10 @@ const Template: ComponentStory<typeof Home> = (args) => <Home {...args} />;
 export const Default = Template.bind({});
 Default.args = {
   popularTopics: POPULAR_TOPICS,
+};
+
+export const WithLogin = Template.bind({});
+WithLogin.args = Default.args;
+WithLogin.parameters = {
+  storage: LOGGED_IN,
 };

--- a/src/pages/topic/[id].stories.tsx
+++ b/src/pages/topic/[id].stories.tsx
@@ -1,8 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import { LOGGED_IN } from '@mocks/data/localStorage';
 import { TOPIC_DETAIL } from '@mocks/data/topic';
-
-import { localstorageKeys } from '@src/constants/localstorage';
 
 import TopicDetail from './[id].page';
 
@@ -22,24 +21,14 @@ Template.parameters = {
   },
 };
 
-export const 비로그인 = Template.bind({});
-비로그인.args = {
+export const Default = Template.bind({});
+Default.args = {
   topicDetail: TOPIC_DETAIL,
 };
-비로그인.decorators = [
-  (Story) => {
-    localStorage.removeItem(localstorageKeys.user);
-    return <Story />;
-  },
-];
 
-export const 로그인 = Template.bind({});
-로그인.args = {
-  topicDetail: TOPIC_DETAIL,
+export const WithLogin = Template.bind({});
+WithLogin.args = Default.args;
+WithLogin.parameters = {
+  ...Default.parameters,
+  storage: LOGGED_IN,
 };
-로그인.decorators = [
-  (Story) => {
-    localStorage.setItem(localstorageKeys.user, JSON.stringify({ accessToken: 'token' }));
-    return <Story />;
-  },
-];

--- a/src/pages/write/WritePage.stories.tsx
+++ b/src/pages/write/WritePage.stories.tsx
@@ -1,6 +1,8 @@
 import { ComponentStory } from '@storybook/react';
 import React from 'react';
 
+import { LOGGED_IN } from '@mocks/data/localStorage';
+
 import WritePage from './index.page';
 
 export default {
@@ -11,3 +13,6 @@ export default {
 const Template: ComponentStory<typeof WritePage> = (args) => <WritePage {...args} />;
 
 export const Default = Template.bind({});
+Default.parameters = {
+  storage: LOGGED_IN,
+};


### PR DESCRIPTION
close #121 

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- 각 스토리별로 별도의 localStorage를 관리하도록 변경

## 📝 작업 내용
<!-- 작업 내용 -->

- localStorageDecorator 구현
- 각 페이지별 로그인 상태의 스토리 추가
- 공통적으로 사용할 mock데이터 추가

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

- #113 과 어느정도 충돌이 있을 예정

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

