### PR TITLE
[feat] refresh token 기반 토큰 재발급

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+import { localstorageKeys } from '@src/constants/localstorage';
 import { Onboarding } from '@src/pages/onboarding/index.page';
 
 import { BaseResponse } from '.';
@@ -51,6 +52,26 @@ export const checkNickName = async (nickName: string) => {
   const res = await axios.post<PostCheckNickName>(`/nickname-duplication`, {
     nickname: nickName,
   });
+
+  return res.data.data;
+};
+
+export type RefreshTokenResponse = BaseResponse<Auth['jwtTokens']>;
+export const refreshToken = async () => {
+  const user = localStorage.getItem(localstorageKeys.user);
+  if (!user) return;
+  const { refreshToken } = JSON.parse(user) as Auth['jwtTokens'];
+  if (!refreshToken) return;
+
+  const res = await axios.post<RefreshTokenResponse>(`/refresh`, null, {
+    headers: {
+      'refresh-token': refreshToken,
+    },
+  });
+  const code = res.data.code;
+  if (Number(code) === 2003 || Number(code) === 2005 || Number(code) === 2006) {
+    localStorage.removeItem(localstorageKeys.user);
+  }
 
   return res.data.data;
 };


### PR DESCRIPTION
close #116

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- 토큰 기간 만료 시 재발급

## 📝 작업 내용
<!-- 작업 내용 -->

- 재발급 api 호출 구현
- response에서 code가 2002(코드 만료)일 때 재발급하도록 변경

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

- 이슈에 적은 대로 토큰이 완전히 만료되어 유효하지 않을 때 어떻게 처리해야할지 방법이 잘 생각나질 않습니다 😢 
- 실험해볼 수 있는 환경을 어떻게 만들어야할지 몰라서,,, 일단 해당 PR은 보류하고 일요일에 모였을 때 해봐야하지 않나 싶기도 합니다.

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

