### PR TITLE
[fix] TopicCardProps 오류 해결

### DIFF
--- a/src/components/common/TopicCard/TopicCard.tsx
+++ b/src/components/common/TopicCard/TopicCard.tsx
@@ -18,7 +18,9 @@ import * as S from './TopicCard.styles';
 
 export type TopicCardType = 'feed' | 'detail';
 
-export interface TopicCardProps extends Omit<Topic, 'tags'> {
+export interface TopicCardProps extends Omit<Topic, 'tags' | 'liked' | 'likeAmount'> {
+  liked?: boolean;
+  likeAmount?: number;
   badge?: string; // TODO: Icon등의 형태 논의 필요
   type: TopicCardType;
   onClick?: () => void;
@@ -44,7 +46,7 @@ const TopicCard = (props: TopicCardProps, ref: React.ForwardedRef<HTMLDivElement
   const { likeTopic } = useLikeTopic();
   const checkAuth = useAuthCheck();
 
-  const [like, setLike] = useState<boolean>(liked);
+  const [like, setLike] = useState<boolean>(!!liked);
   const [likes, setLikes] = useState<number>(likeAmount || 0);
   const [options, setOptions] = useState<VoteOption[]>(defaultOptions);
   const selectedOption = options.find((option) => option.voted);


### PR DESCRIPTION
close #148 

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

빌드 시 오류 해결

## 📝 작업 내용
<!-- 작업 내용 -->

- `TopicCardProps`의 `liked`, `likeAmount`가 Detail 페이지에서만 사용되어 optional하게 변경

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

