### PR TITLE
[feat] 로그인 약관 링크 추가

### DIFF
--- a/src/components/login/Login/Login.styles.tsx
+++ b/src/components/login/Login/Login.styles.tsx
@@ -55,4 +55,9 @@ export const Terms = styled.p`
   line-height: ${theme.lineHeight.B};
   text-align: center;
   color: ${theme.color.G7};
+
+  a {
+    text-decoration: underline;
+    font-weight: bolder;
+  }
 `;

--- a/src/components/login/Login/Login.tsx
+++ b/src/components/login/Login/Login.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
 import Icon from '@src/components/common/Icon';
+import LINK_URL from '@src/constants/link';
 
 import * as S from './Login.styles';
 
@@ -14,7 +15,17 @@ const Login: FC = () => {
         <Icon name="GoogleLogo" size={16} />
         Google 계정으로 로그인
       </S.GoogleLogin>
-      <S.Terms>로그인은 서비스 이용약관 및 개인정보 처리방침에 동의함을 의미하며,</S.Terms>
+      <S.Terms>
+        로그인은{' '}
+        <a target="_blank" href={LINK_URL.termsOfUse} rel="noreferrer">
+          서비스 이용약관
+        </a>{' '}
+        및{' '}
+        <a target="_blank" href={LINK_URL.privacyPolicy} rel="noreferrer">
+          개인정보 처리방침
+        </a>
+        에 동의함을 의미하며,
+      </S.Terms>
       <S.Terms>서비스 이용을 위해 이메일과 이름, 프로필 이미지를 수집합니다.</S.Terms>
     </S.Wrapper>
   );

--- a/src/constants/link.ts
+++ b/src/constants/link.ts
@@ -1,5 +1,7 @@
 const LINK_URL = {
   enquiryGoogleForm: 'https://forms.gle/awhsLVEDGLfV4XzUA',
+  termsOfUse: 'https://inspiringjack.notion.site/0a14d33b317042af9b395bdd28666acc',
+  privacyPolicy: 'https://inspiringjack.notion.site/a2707b224ea54c83b7ee0a682ddfa563',
 };
 
 export default LINK_URL;


### PR DESCRIPTION
close #154 

## 💡 개요
![image](https://user-images.githubusercontent.com/45627868/220612706-dfd84ffe-94cf-4691-92a4-e071642f718c.png)
- `서비스 이용약관` , `개인정보 처리방침` 클릭 시 텀즈업 약관으로 이동

## 📝 작업 내용
- [x] "서비스 이용 약관" 및 "개인 정보 처리 방침" 에 해당 하는 링크 연결 (새로운 창에서 뜨도록)

## ‼️ 주의 사항

## 🔗 참고자료

