### PR TITLE
[fix] 온보딩 과정(회원가입)에서 완료하지 않고 새로고침 후 진행하면 회원가입 실패

### DIFF
--- a/src/pages/auth.page.tsx
+++ b/src/pages/auth.page.tsx
@@ -22,7 +22,7 @@ const Auth = () => {
           setUserSession(result.jwtTokens);
           router.push('/');
         } else {
-          router.push(`/onboarding?code=${result?.jwtTokens.accessToken}`, '/onboarding');
+          router.push(`/onboarding?code=${result?.jwtTokens.accessToken}`);
         }
       },
       onError: async () => {


### PR DESCRIPTION
close #156 

## 💡 개요
- 회원가입 진행시 새로고침 후 진행하면 회원가입 안되는 이슈 수정

## 📝 작업 내용
- [x] 회원가입 도중에 새로고침 후 다시 진행되더라도 정상적으로 회원가입하기

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

