### PR TITLE
[refactor] 로그인 검증 공통 로직 분리

### DIFF
--- a/src/components/common/TopicCard/TopicCard.stories.tsx
+++ b/src/components/common/TopicCard/TopicCard.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentStory } from '@storybook/react';
 import React from 'react';
 
-import { LOGGED_IN } from '@mocks/data/localStorage';
+import { LOGGED_IN } from '@mocks/data/cookie';
 import { MEMBER } from '@mocks/data/member';
 import {
   VOTE_OPTION,

--- a/src/components/common/TopicCard/TopicCard.stories.tsx
+++ b/src/components/common/TopicCard/TopicCard.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentStory } from '@storybook/react';
 import React from 'react';
 
+import { LOGGED_IN } from '@mocks/data/localStorage';
 import { MEMBER } from '@mocks/data/member';
 import {
   VOTE_OPTION,
@@ -11,11 +12,16 @@ import {
   VOTE_OPTION_WITH_SHORT_CODE,
 } from '@mocks/data/voteOption';
 
+import { localstorageKeys } from '@src/constants/localstorage';
+
 import TopicCard from '.';
 
 export default {
   component: TopicCard,
   title: 'common/TopicCard',
+  parameters: {
+    storage: LOGGED_IN,
+  },
 };
 
 const Template: ComponentStory<typeof TopicCard> = (args) => <TopicCard {...args} />;
@@ -29,6 +35,12 @@ Default.args = {
   member: MEMBER,
   commentAmount: 0,
   type: 'feed',
+};
+
+export const WithoutLogin = Template.bind({});
+WithoutLogin.args = Default.args;
+WithoutLogin.parameters = {
+  storage: { [localstorageKeys.user]: null },
 };
 
 export const 글자수_많음_2개 = Template.bind({});

--- a/src/components/common/TopicCard/TopicCard.tsx
+++ b/src/components/common/TopicCard/TopicCard.tsx
@@ -1,6 +1,4 @@
-import { useRouter } from 'next/router';
 import React, { useState } from 'react';
-import { useRecoilValue } from 'recoil';
 
 import { LikeTopicResponseData } from '@src/apis';
 import ProfileImg from '@src/components/common/ProfileImg';
@@ -8,7 +6,6 @@ import ShareIcon from '@src/components/common/ShareIcon';
 import useAuthCheck from '@src/hooks/useAuthCheck';
 import useLikeTopic from '@src/queires/useLikeTopic';
 import { useVote } from '@src/queires/useVote';
-import $userSession from '@src/recoil/userSession';
 import Topic from '@src/types/Topic';
 import VoteOption from '@src/types/VoteOption';
 
@@ -40,8 +37,6 @@ const TopicCard = (props: TopicCardProps, ref: React.ForwardedRef<HTMLDivElement
     type,
     onClick,
   } = props;
-  const tokens = useRecoilValue($userSession);
-  const router = useRouter();
   const { vote } = useVote();
   const { likeTopic } = useLikeTopic();
   const checkAuth = useAuthCheck();
@@ -64,23 +59,8 @@ const TopicCard = (props: TopicCardProps, ref: React.ForwardedRef<HTMLDivElement
   };
 
   const handleClickOption = async (voteOptionId: number) => {
-    if (!tokens) {
-      alert('로그인이 필요합니다!');
-      await router.push('/login');
-      return;
-    }
-
-    try {
-      await vote({
-        topicId,
-        voteOptionId,
-      });
-    } catch (err) {
-      // TODO: 에러핸들링 추가 필요
-      alert('로그인이 필요합니다!');
-      await router.push('/login');
-      return;
-    }
+    const result = await checkAuth(() => vote({ topicId, voteOptionId }));
+    if (!result) return;
 
     const changed = options.map((option) => {
       if (option.voteOptionId === selectedOptionId) {

--- a/src/components/main/Main/Main.tsx
+++ b/src/components/main/Main/Main.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
 
 import { GetTopicsResponseData } from '@src/apis';
 import AddButton from '@src/components/main/AddButton';
@@ -8,7 +7,7 @@ import FabButton from '@src/components/main/FabButton';
 import MainTopicList from '@src/components/main/MainTopicList';
 import { MenuCategory } from '@src/components/main/SideMenu/SideMenu';
 import TopicCarousel from '@src/components/main/TopicCarousel';
-import $userSession from '@src/recoil/userSession';
+import useAuthCheck from '@src/hooks/useAuthCheck';
 
 import * as S from './Main.styles';
 
@@ -22,7 +21,7 @@ const Main: React.FC<MainProps> = (props) => {
   const [fabVisible, setFabVisible] = useState<boolean>(false);
   const observerRef = useRef<HTMLDivElement>(null);
 
-  const tokens = useRecoilValue($userSession);
+  const checkAuth = useAuthCheck();
   const router = useRouter();
 
   const handleObserver: IntersectionObserverCallback = useCallback(
@@ -38,12 +37,7 @@ const Main: React.FC<MainProps> = (props) => {
   }, [handleObserver]);
 
   const handleWrite = async () => {
-    if (!tokens) {
-      alert('로그인이 필요합니다!');
-      await router.push('/login');
-      return;
-    }
-    await router.push('/write');
+    await checkAuth(() => router.push('/write'));
   };
 
   return (

--- a/src/hooks/useAuthCheck.ts
+++ b/src/hooks/useAuthCheck.ts
@@ -9,12 +9,14 @@ const useAuthCheck = () => {
   const tokens = useRecoilValue($userSession);
   const router = useRouter();
 
-  return async <T>(callback: () => Promise<T | undefined>): Promise<T | undefined> => {
+  return async <T>(callback?: () => Promise<T | void>): Promise<T | void> => {
     if (!tokens) {
       alert('로그인이 필요합니다!');
       await router.push('/login');
       return;
     }
+
+    if (!callback) return;
 
     try {
       return await callback();

--- a/src/pages/write/index.page.tsx
+++ b/src/pages/write/index.page.tsx
@@ -1,24 +1,20 @@
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
 
 import { PostTopicRequest } from '@src/apis';
 import Header from '@src/components/common/Header';
 import WriteMain from '@src/components/write/WriteMain';
+import useAuthCheck from '@src/hooks/useAuthCheck';
 import useCreateTopic from '@src/queires/useCreateTopic';
-import $userSession from '@src/recoil/userSession';
 
 const WritePage: NextPage = () => {
   const { createTopic } = useCreateTopic();
-  const tokens = useRecoilValue($userSession);
+
+  const checkAuth = useAuthCheck();
   const router = useRouter();
 
-  useEffect(() => {
-    if (tokens) return;
-    alert('로그인이 필요합니다!');
-    router.push('/login');
-  }, [router, tokens]);
+  const isNotAuth = !!checkAuth();
+  if (isNotAuth) return null;
 
   const handleCreate = async (topic: PostTopicRequest) => {
     await createTopic(topic);


### PR DESCRIPTION
close #138

## 💡 개요
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- useAuthCheck를 사용해서 공통 로직 분리

## 📝 작업 내용
<!-- 작업 내용 -->

- 투표하기
- 글쓰기 페이지 이동

## ‼️ 주의 사항
<!-- 해당 작업에서 주의해아할 사항  -->

- 개발 환경에서는 /write로 직접 이동 시 렌더링이 두번 되면서 alert 역시 2번 뜹니다.
- 이는 next의 strictMode 때문에 개발 환경에서만 그런 거라고 하더라고요. [참고 Issues](https://github.com/vercel/next.js/issues/35822#issuecomment-1100924022)

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

